### PR TITLE
External encoding - corrige alguns problemas de acentuação no Ruby 1.9

### DIFF
--- a/lib/brcobranca.rb
+++ b/lib/brcobranca.rb
@@ -47,7 +47,7 @@ module Brcobranca
   # Para mudar as configurações padrão, você pode fazer assim:
   # config/environments/test.rb:
   #
-  #     Brcobranca.configure do |config|
+  #     Brcobranca.setup do |config|
   #       config.formato = :gif
   #     end
   #
@@ -67,6 +67,13 @@ module Brcobranca
     # @return [Integer]
     # @param  [Integer] (Padrão: 150)
     attr_accessor :resolucao
+
+    # Ajusta o Encoding externo (do arquivo) - Ruby 1.9
+    # Ex: Caso esteja dando UndefinedConversionError - from ASCII-8BIT to UTF-8
+    # configurar com a string 'ascii-8bit'
+    # @return [String]
+    # @param  [String] (Padrão: nil)
+    attr_accessor :external_encoding
 
     # Atribui valores padrões de configuração
     def initialize
@@ -110,3 +117,4 @@ module Brcobranca
     autoload :RetornoCbr643,  'brcobranca/retorno/retorno_cbr643'
   end
 end
+

--- a/lib/brcobranca/boleto/template/rghost.rb
+++ b/lib/brcobranca/boleto/template/rghost.rb
@@ -23,6 +23,7 @@ module Brcobranca
       module Rghost
         extend self
         include RGhost unless self.include?(RGhost)
+        RGhost::Config::GS[:external_encoding] = Brcobranca.configuration.external_encoding
 
         # Gera o boleto em usando o formato desejado [:pdf, :jpg, :tif, :png, :ps, :laserjet, ... etc]
         #
@@ -225,3 +226,4 @@ module Brcobranca
     end
   end
 end
+


### PR DESCRIPTION
Olá Kivanio,

Eu estava tendo alguns problemas com acentos gerando o seguinte erro: UndefinedConversionError - … from ASCII-8BIT to UTF-8. Consegui resolver alterando o rghost para abrir o arquivo com a opção "external_encoding" setada para 'ascii-8bit'.

Enviei um pull request para o rghost incluindo esta opção e já foi aplicado no rghost-0.8.7.6.

Criei uma opção no brcobranca para ativar esta funcionalidade do rghost.

Exemplo:
No config/initializers/brcobranca.rb

  Brcobranca.setup do |config|
    config.external_encoding = 'ascii-8bit'
  end
- Só lembrando que depende do rghost versão 0.8.7.6 ou superior

Obrigado
