### PR TITLE
Adicionado suporte ao valor da tarifa no arquivo retorno CNAB240

### DIFF
--- a/lib/brcobranca/retorno/retorno_cnab240.rb
+++ b/lib/brcobranca/retorno/retorno_cnab240.rb
@@ -38,7 +38,7 @@ module Brcobranca
       class Line < Base
         extend ParseLine::FixedWidth # Extendendo parseline
 
-        REGISTRO_T_FIELDS = %w(agencia_com_dv cedente_com_dv nosso_numero carteira data_vencimento valor_titulo banco_recebedor agencia_recebedora_com_dv sequencial)
+        REGISTRO_T_FIELDS = %w(agencia_com_dv cedente_com_dv nosso_numero carteira data_vencimento valor_titulo banco_recebedor agencia_recebedora_com_dv sequencial valor_tarifa)
         REGISTRO_U_FIELDS = %w(desconto_concedito valor_abatimento iof_desconto juros_mora valor_recebido outras_despesas outros_recebimento data_credito)
 
         attr_accessor :tipo_registro
@@ -62,6 +62,7 @@ module Brcobranca
           parse.field :valor_recebido,77..91
           parse.field :juros_mora,17..31
           parse.field :outros_recebimento,122..136
+          parse.field :valor_tarifa,198..212
 
           # Dados que não consegui extrair dos registros T e U
           #parse.field :convenio,31..37

--- a/spec/brcobranca/retorno_cnab_240_spec.rb
+++ b/spec/brcobranca/retorno_cnab_240_spec.rb
@@ -27,6 +27,7 @@ describe Brcobranca::Retorno::RetornoCnab240 do
     pagamento.juros_mora.should eql('000000000000009')
     pagamento.outros_recebimento.should eql('000000000000005')
     pagamento.sequencial.should eql('00001')
+    pagamento.valor_tarifa.should eql('000000000000103')
 
     # Dados que não consegui extrair dos registros T e U
     #pagamento.convenio.should eql('')


### PR DESCRIPTION
Conforme informações contidas na documentação da caixa, página 19, disponível em [1] o valor da tarifa está contido no arquivo.

[1] http://downloads.caixa.gov.br/_arquivos/cobrcaixasicob/manuaissicob/CNAB_240_SICOB.pdf
