### PR TITLE
Corrigida formatacao de CPF quando o mesmo já está formatado

### DIFF
--- a/lib/brcobranca/formatacao.rb
+++ b/lib/brcobranca/formatacao.rb
@@ -9,7 +9,7 @@ module Brcobranca
     # @example
     #  "12345678901".to_br_cpf #=> 123.456.789-01
     def to_br_cpf
-      self.to_s.gsub(/^(.{3})(.{3})(.{3})(.{2})$/,'\1.\2.\3-\4')
+      somente_numeros.gsub(/^(.{3})(.{3})(.{3})(.{2})$/,'\1.\2.\3-\4')
     end
 
     # Formata como CEP
@@ -19,7 +19,7 @@ module Brcobranca
     #   "85253100".to_br_cep #=> "85253-100"
     #   85253100.to_br_cep #=> "85253-100"
     def to_br_cep
-      self.to_s.gsub(/^(.{5})(.{3})$/,'\1-\2')
+      somente_numeros.gsub(/^(.{5})(.{3})$/,'\1-\2')
     end
 
     # Formata como CNPJ
@@ -28,7 +28,7 @@ module Brcobranca
     # @example
     #  "12345678000901".to_br_cnpj #=> 12.345.678/0009-01
     def to_br_cnpj
-      self.to_s.gsub(/^(.{2})(.{3})(.{3})(.{4})(.{2})$/,'\1.\2.\3/\4-\5')
+      somente_numeros.gsub(/^(.{2})(.{3})(.{3})(.{4})(.{2})$/,'\1.\2.\3/\4-\5')
     end
 
     # Gera formatação automática do documento baseado no tamanho do campo.
@@ -40,10 +40,10 @@ module Brcobranca
     #  "12345678901".formata_documento #=> 123.456.789-01
     #  "12345".formata_documento #=> 12345
     def formata_documento
-      case self.to_s.size
-      when 8 then self.to_br_cep
-      when 11 then self.to_br_cpf
-      when 14 then self.to_br_cnpj
+      case somente_numeros.size
+      when 8 then to_br_cep
+      when 11 then to_br_cpf
+      when 14 then to_br_cnpj
       else
         self
       end
@@ -55,7 +55,7 @@ module Brcobranca
     # @example
     #   1a23e45+".somente_numeros #=> 12345
     def somente_numeros
-      self.to_s.gsub(/\D/,'')
+      to_s.gsub(/\D/,'')
     end
 
     # Monta a linha digitável padrão para todos os bancos segundo a BACEN.

--- a/spec/brcobranca/core_ext_spec.rb
+++ b/spec/brcobranca/core_ext_spec.rb
@@ -6,25 +6,31 @@ module Brcobranca
     it "Formata o CPF" do
       98789298790.to_br_cpf.should eql("987.892.987-90")
       "98789298790".to_br_cpf.should eql("987.892.987-90")
+      "987.892.987-90".to_br_cpf.should eql("987.892.987-90")
     end
 
     it "Formata o CEP" do
       85253100.to_br_cep.should eql("85253-100")
       "85253100".to_br_cep.should eql("85253-100")
+      "85253-100".to_br_cep.should eql("85253-100")
     end
 
     it "Formata o CNPJ" do
       88394510000103.to_br_cnpj.should eql("88.394.510/0001-03")
       "88394510000103".to_br_cnpj.should eql("88.394.510/0001-03")
+      "88.394.510/0001-03".to_br_cnpj.should eql("88.394.510/0001-03")
     end
 
     it "Formata números automáticamente de acordo com o número de caracteres" do
       98789298790.formata_documento.should eql("987.892.987-90")
       "98789298790".formata_documento.should eql("987.892.987-90")
+      "987.892.987-90".formata_documento.should eql("987.892.987-90")
       85253100.formata_documento.should eql("85253-100")
       "85253100".formata_documento.should eql("85253-100")
+      "85253-100".formata_documento.should eql("85253-100")
       88394510000103.formata_documento.should eql("88.394.510/0001-03")
       "88394510000103".formata_documento.should eql("88.394.510/0001-03")
+      "88.394.510/0001-03".formata_documento.should eql("88.394.510/0001-03")
       "8839".formata_documento.should eql("8839")
       "8839451000010388394510000103".formata_documento.should eql("8839451000010388394510000103")
     end


### PR DESCRIPTION
Fala pessoal, tudo bem ?

Primeiramente, parabéns pela gem. Realmente quebra um galhão quando se precisa de uma solução para boletos bancários, tarefa esta que é meio corriqueira. Infelizmente, tive um problema em dois projetos, os quais utilizavam o CPF dos clientes providos de um Webservice, que já vinham formatados. O que acontece é que o método formata_documento confia no tamanho da string e, quando um CPF já vem formatado, o mesmo tem 14 caracteres e acaba sendo formatado como um CNPJ, da seguinte maneira:

CPF: "999.999.999-99"
Formatação Resultante: "99.9.9.99./999--99"

Óbviamente, isso é fácilmente resolvido se a formatação for feita na geração do boleto, mas acredito que a responsabilidade desta tarefa é de quem renderiza o boleto, no caso a gem =P

Fiz a correção que agora utiliza a string sem caracteres especiais para determinar o tipo de documento mediante ao seu tamanho. Isso resolve este problema que tive e que inclusive alguns amigos desenvolvedores tiveram. Adicionei testes para os casos onde a gem pode receber CEP, CPF ou CNPJ já formatados.

Espero que o PR seja aceito, e qualquer dúvida só chamar ! Valeu !!
