### PR TITLE
Antendido item 4.2.2.1 (local de pagamento) do manual da Caixa

### DIFF
--- a/lib/brcobranca/boleto/caixa.rb
+++ b/lib/brcobranca/boleto/caixa.rb
@@ -26,11 +26,12 @@ module Brcobranca
       # @param (see Brcobranca::Boleto::Base#initialize)
       def initialize campos = {} 
         campos = {
-          :carteira => "#{MODALIDADE_COBRANCA[:sem_registro]}#{EMISSAO_BOLETO[:cedente]}" 
+          :carteira => "#{MODALIDADE_COBRANCA[:sem_registro]}#{EMISSAO_BOLETO[:cedente]}"
         }.merge!(campos)
 
         campos.merge!(:convenio => campos[:convenio].rjust(6, '0')) if campos[:convenio]
         campos.merge!(:numero_documento => campos[:numero_documento].rjust(15, '0')) if campos[:numero_documento]
+        campos.merge!(:local_pagamento => "PREFERENCIALMENTE NAS CASAS LOTÉRICAS ATÉ O VALOR LIMITE")
 
         super(campos)
       end

--- a/spec/brcobranca/banco_caixa_spec.rb
+++ b/spec/brcobranca/banco_caixa_spec.rb
@@ -12,7 +12,6 @@ describe Brcobranca::Boleto::Caixa do #:nodoc:[all]
       :aceite => 'S',
       :quantidade => 1,
       :valor => 10.00,
-      :local_pagamento => 'QUALQUER BANCO ATÉ O VENCIMENTO',
       :cedente => 'PREFEITURA MUNICIPAL DE VILHENA',
       :documento_cedente => '04092706000181',
       :sacado => 'João Paulo Barbosa',
@@ -38,7 +37,7 @@ describe Brcobranca::Boleto::Caixa do #:nodoc:[all]
     boleto_novo.quantidade.should eql(1)
     boleto_novo.valor.should eql(0.0)
     boleto_novo.valor_documento.should eql(0.0)
-    boleto_novo.local_pagamento.should eql('QUALQUER BANCO ATÉ O VENCIMENTO')
+    boleto_novo.local_pagamento.should eql('PREFERENCIALMENTE NAS CASAS LOTÉRICAS ATÉ O VALOR LIMITE')
     boleto_novo.codigo_servico.should be_false
     carteira = "#{Brcobranca::Boleto::Caixa::MODALIDADE_COBRANCA[:sem_registro]}" <<
                "#{Brcobranca::Boleto::Caixa::EMISSAO_BOLETO[:cedente]}"


### PR DESCRIPTION
Deve apresentar a expressão “PREFERENCIALMENTE NAS CASAS LOTÉRICAS ATÉ O VALOR LIMITE” no campo "local de pagamento", de acordo com o item 4.2.2.1 do manual, então defini isso como obrigatório.
