### PR TITLE
Compatibilidade com Rails 4 (>=3)

### DIFF
--- a/brcobranca.gemspec
+++ b/brcobranca.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency(%q<rghost>, ["~> 0.9"])
   s.add_runtime_dependency(%q<rghost_barcode>, ["~> 0.9"])
   s.add_runtime_dependency(%q<parseline>, [">= 1.0.3"])
-  s.add_runtime_dependency(%q<activemodel>, ["~> 3"])
+  s.add_runtime_dependency(%q<activemodel>, [">= 3"])
 
   s.post_install_message = %[
     ===========================================================================


### PR DESCRIPTION
Altera arquivo brcobranca.gemspec para a gem rodar também em Rails 4.x, mantendo a compatibilidade com Rails 3.x
