### PR TITLE
Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: ruby
+rvm:
+  - 1.9.3
+  - 2.0.0
+  - 2.1.0
+  - jruby
+  - rbx
+matrix:
+  allow_failures:
+    - rvm: jruby
+    - rvm: rbx


### PR DESCRIPTION
Arquivo para habilitar testes do travis, vai ajudar a dar uma vazão nos pull requests (pois vai mostrar os que estão quebrando testes, etc).

Para ativar, tem que visitar o Travis CI e "ligar" o repositório.
