### PR TITLE
Validação para byte de geração da Sicredi

### DIFF
--- a/lib/brcobranca/boleto/sicredi.rb
+++ b/lib/brcobranca/boleto/sicredi.rb
@@ -1,4 +1,8 @@
 # -*- encoding: utf-8 -*-
+#
+# Sicredi
+# Documentação: http://www.shapeness.net.br/upload//Sicredi_240.pdf
+#
 module Brcobranca
   module Boleto
     class Sicredi < Base # Banco SICREDI
@@ -8,10 +12,11 @@ module Brcobranca
       # <b>REQUERIDO</b>: Byte de identificação do cedente do bloqueto utilizado para compor o nosso número.
       attr_accessor :byte_idt
 
-      validates_length_of :agencia, :maximum => 4, :message => "deve ser menor ou igual a 4 dígitos."
-      validates_length_of :numero_documento, :maximum => 5, :message => "deve ser menor ou igual a 5 dígitos."
-      validates_length_of :conta_corrente, :maximum => 5, :message => "deve ser menor ou igual a 5 dígitos."
-      validates_length_of :carteira, :maximum => 2, :message => "deve ser menor ou igual a 2 dígitos."
+      validates_length_of :agencia, :maximum => 4, :message => 'deve ser menor ou igual a 4 dígitos.'
+      validates_length_of :numero_documento, :maximum => 5, :message => 'deve ser menor ou igual a 5 dígitos.'
+      validates_length_of :conta_corrente, :maximum => 5, :message => 'deve ser menor ou igual a 5 dígitos.'
+      validates_length_of :carteira, :maximum => 2, :message => 'deve ser menor ou igual a 2 dígitos.'
+      validates_length_of :byte_idt, :is => 1, :message => 'deve ser 1 se o numero foi gerado pela agencia ou 2-9 se foi gerado pelo cedente'
 
       # Nova instancia do Bradesco
       # @param (see Brcobranca::Boleto::Base#initialize)
@@ -56,7 +61,7 @@ module Brcobranca
       # Nosso número para exibir no boleto.
       # @return [String]
       # @example
-      #  boleto.nosso_numero_boleto #=> "06/00000004042-8"
+      #  boleto.nosso_numero_boleto #=> "14/200022-5"
       def nosso_numero_boleto
         "#{numero_documento_with_byte_idt[0..1]}/#{numero_documento_with_byte_idt[2..-1]}-#{self.nosso_numero_dv}"
       end

--- a/spec/brcobranca/banco_sicredi_spec.rb
+++ b/spec/brcobranca/banco_sicredi_spec.rb
@@ -89,7 +89,7 @@ describe Brcobranca::Boleto::Sicredi do
   it "Não permitir gerar boleto com atributos inválido" do
     boleto_novo = Brcobranca::Boleto::Sicredi.new
     lambda { boleto_novo.codigo_barras }.should raise_error(Brcobranca::BoletoInvalido)
-    boleto_novo.errors.count.should eql(3)
+    boleto_novo.errors.count.should eql(4)
   end
 
   it "Montar nosso_numero_boleto" do


### PR DESCRIPTION
Sem essa validação não é garantido que o nosso numero estará completo
e portanto, pode falhar sem nenhuma mensagem pro usuário,
o que é algo ruim e indesejado.

Corrige o #53
