### PR TITLE
BUGFIX: Arredondamento do valor formatado.

### DIFF
--- a/lib/brcobranca/boleto/base.rb
+++ b/lib/brcobranca/boleto/base.rb
@@ -211,7 +211,7 @@ module Brcobranca
       # Valor total do documento
       # @return [String] 10 caracteres numéricos.
       def valor_documento_formatado
-        self.valor_documento.limpa_valor_moeda.to_s.rjust(10,'0')
+        self.valor_documento.round(2).limpa_valor_moeda.to_s.rjust(10,'0')
       end
 
       # Nome da classe do boleto


### PR DESCRIPTION
Havia um problema na impressão do boleto quando o valor continha mais de 2 casas decimais. O valor no código de barras ficava diferente ao valor real. Ex:

Valor: 123,456
No código de barras ficava 123456 (equivalente a 1.234,56)
