### PR TITLE
Ajusta posição do atributo 'cedente'

### DIFF
--- a/lib/brcobranca/boleto/template/rghost.rb
+++ b/lib/brcobranca/boleto/template/rghost.rb
@@ -175,10 +175,14 @@ module Brcobranca
           doc.show boleto.local_pagamento
           doc.moveto x: '16.5 cm', y: '16 cm'
           doc.show boleto.data_vencimento.to_s_br if boleto.data_vencimento
-          doc.moveto x: '1.9 cm', y: '15.5 cm'
-          doc.show boleto.cedente
           doc.moveto x: '0.7 cm', y: '15.2 cm'
-          doc.show boleto.cedente_endereco
+          if boleto.cedente_endereco
+            doc.show boleto.cedente_endereco
+            doc.moveto x: '1.9 cm', y: '15.5 cm'
+            doc.show boleto.cedente
+          else
+            doc.show boleto.cedente
+          end
           doc.moveto x: '16.5 cm', y: '15.2 cm'
           doc.show boleto.agencia_conta_boleto
           doc.moveto x: '0.7 cm', y: '14.4 cm'


### PR DESCRIPTION
Quando o 'cedente_endereco' não é informado, o atributo 'cedente' estava no lugar errado

Closes #83