### PR TITLE
Validações da data do documento

### DIFF
--- a/lib/brcobranca/boleto/base.rb
+++ b/lib/brcobranca/boleto/base.rb
@@ -156,7 +156,7 @@ module Brcobranca
       # @return [Date]
       # @raise [ArgumentError] Caso {#data_documento} esteja em branco.
       def data_vencimento
-        fail ArgumentError, 'data_documento não pode estar em branco.' unless data_documento
+        fail ArgumentError, 'data_documento não pode estar em branco.' unless data_documento.present?
         return data_documento unless dias_vencimento
         (data_documento + dias_vencimento.to_i)
       end

--- a/lib/brcobranca/boleto/base.rb
+++ b/lib/brcobranca/boleto/base.rb
@@ -156,7 +156,7 @@ module Brcobranca
       # @return [Date]
       # @raise [ArgumentError] Caso {#data_documento} esteja em branco.
       def data_vencimento
-        fail ArgumentError, 'data_documento não pode estar em branco.' unless data_documento.present?
+        fail ArgumentError, 'Data Documento não pode estar em branco.' unless data_documento.present?
         return data_documento unless dias_vencimento
 
         self.data_documento = Date.parse(data_documento) if data_documento.is_a?(String)

--- a/lib/brcobranca/boleto/base.rb
+++ b/lib/brcobranca/boleto/base.rb
@@ -158,6 +158,8 @@ module Brcobranca
       def data_vencimento
         fail ArgumentError, 'data_documento não pode estar em branco.' unless data_documento.present?
         return data_documento unless dias_vencimento
+
+        self.data_documento = Date.parse(data_documento) if data_documento.is_a?(String)
         (data_documento + dias_vencimento.to_i)
       end
 

--- a/spec/brcobranca/base_spec.rb
+++ b/spec/brcobranca/base_spec.rb
@@ -185,6 +185,11 @@ module Brcobranca #:nodoc:[all]
           boleto_novo = Brcobranca::Boleto::Base.new(data_documento: '')
           expect{ boleto_novo.data_vencimento }.to raise_error(/data_documento não pode estar em branco/)
         end
+
+        it 'data_documento em string' do
+          boleto_novo = Brcobranca::Boleto::Base.new(data_documento: '2015-06-15')
+          expect(boleto_novo.data_vencimento).to eql(Date.parse('2015-06-16'))
+        end
       end
     end
   end

--- a/spec/brcobranca/base_spec.rb
+++ b/spec/brcobranca/base_spec.rb
@@ -183,7 +183,7 @@ module Brcobranca #:nodoc:[all]
       context 'Validações' do
         it 'data_documento em branco' do
           boleto_novo = Brcobranca::Boleto::Base.new(data_documento: '')
-          expect{ boleto_novo.data_vencimento }.to raise_error(/data_documento não pode estar em branco/)
+          expect{ boleto_novo.data_vencimento }.to raise_error(/Data Documento não pode estar em branco/)
         end
 
         it 'data_documento em string' do

--- a/spec/brcobranca/base_spec.rb
+++ b/spec/brcobranca/base_spec.rb
@@ -179,6 +179,13 @@ module Brcobranca #:nodoc:[all]
         expect(boleto_novo.respond_to?(:lote)).to be_truthy
         expect(boleto_novo.respond_to?(:to)).to be_truthy
       end
+
+      context 'Validações' do
+        it 'data_documento em branco' do
+          boleto_novo = Brcobranca::Boleto::Base.new(data_documento: '')
+          expect{ boleto_novo.data_vencimento }.to raise_error(/data_documento não pode estar em branco/)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
* Melhorada a mensagem de validação da data do documento
* Validações na data do documento quando é enviado em branco ou string (através de API, por exemplo)

Não vejo problema em utilizar o helper `present?` do `active_support` que é uma dependência do `active_model`. Se for remover a dependência do Rails, podemos transformar isso num helper do projeto mais tarde.