### PR TITLE
Correção do DV de agência de conta corrente do Bradesco. Padronizado Remessa para ASCII upcase.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,3 @@ DEPENDENCIES
   rubocop (~> 0.32.1)
   rubocop-rspec (~> 1.3.0)
   timecop
-
-BUNDLED WITH
-   1.10.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ PATH
       parseline (~> 1.0.3)
       rghost (= 0.9.5)
       rghost_barcode (~> 0.9)
+      unidecoder (>= 1.1.2)
 
 GEM
   remote: https://rubygems.org/
@@ -110,6 +111,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.1)
     unf_ext (0.0.7.1-x86-mingw32)
+    unidecoder (1.1.2)
     win32console (1.3.2-x86-mingw32)
 
 PLATFORMS

--- a/brcobranca.gemspec
+++ b/brcobranca.gemspec
@@ -25,4 +25,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'rghost_barcode', '~> 0.9'
   gem.add_dependency 'parseline', '~> 1.0.3'
   gem.add_dependency 'activemodel', '>= 3'
+
+  gem.add_dependency 'unidecoder', '>= 1.1.2'
 end

--- a/lib/brcobranca/boleto/bradesco.rb
+++ b/lib/brcobranca/boleto/bradesco.rb
@@ -45,8 +45,28 @@ module Brcobranca
         "#{carteira}/#{numero_documento}-#{nosso_numero_dv}"
       end
 
+      # Dígito verificador da agência
+      # @return [Integer] 1 caracteres numéricos.
+      def agencia_dv
+        agencia.modulo11(
+          multiplicador: [2, 3, 4, 5],
+          mapeamento: { 10 => 'P', 11 => 0 }
+        ) { |total| 11 - (total % 11) }
+      end
+
+      # Dígito verificador do nosso número
+      # @return [Integer] 1 caracteres numéricos.
       def nosso_numero_dv
         "#{carteira}#{numero_documento}".modulo11(
+          multiplicador: [2, 3, 4, 5, 6, 7],
+          mapeamento: { 10 => 'P', 11 => 0 }
+        ) { |total| 11 - (total % 11) }
+      end
+
+      # Dígito verificador da conta corrente
+      # @return [Integer] 1 caracteres numéricos.
+      def conta_corrente_dv
+        conta_corrente.modulo11(
           multiplicador: [2, 3, 4, 5, 6, 7],
           mapeamento: { 10 => 'P', 11 => 0 }
         ) { |total| 11 - (total % 11) }

--- a/lib/brcobranca/remessa/cnab400/base.rb
+++ b/lib/brcobranca/remessa/cnab400/base.rb
@@ -3,6 +3,7 @@ module Brcobranca
   module Remessa
     module Cnab400
       class Base < Brcobranca::Remessa::Base
+        require "unidecoder"
         validates_presence_of :carteira, message: 'não pode estar em branco.'
 
         # Data da geracao do arquivo seguindo o padrao DDMMAA
@@ -71,7 +72,7 @@ module Brcobranca
           end
           ret << monta_trailer(contador + 1)
           retorno = ret.join("\n")
-          retorno
+          retorno.to_ascii.upcase
         end
 
         # Informacoes referentes a conta do cedente

--- a/lib/brcobranca/retorno/cnab400/base.rb
+++ b/lib/brcobranca/retorno/cnab400/base.rb
@@ -8,11 +8,9 @@ module Brcobranca
 
         # Load lines
         def self.load_lines(file, options={})
-          arquivo = File.open(file, "r")
-          codigo_banco = arquivo.gets[76..78]
-          arquivo.close
+          return nil if file.blank?
 
-          case codigo_banco
+          case codigo_banco_do_arquivo(file)
           when "237"
             Brcobranca::Retorno::Cnab400::Bradesco.load_lines(file, options)
 
@@ -23,8 +21,18 @@ module Brcobranca
             warn "Banco não encontrado (#{codigo_banco}). Carregando layout antigo padrão (ITAÚ)."
             Brcobranca::Retorno::RetornoCnab400.load_lines(file, options)
           end
-
         end
+
+        # Codigo do banco lido do arquivo.
+        # Registro Header [76..78]
+        def self.codigo_banco_do_arquivo(file)
+          arquivo = File.open(file, "r")
+          header = arquivo.gets
+          codigo_banco = header.blank? ? nil : header[76..78]
+          arquivo.close
+          codigo_banco
+        end
+
       end
     end
   end

--- a/lib/brcobranca/retorno/cnab400/base.rb
+++ b/lib/brcobranca/retorno/cnab400/base.rb
@@ -10,7 +10,9 @@ module Brcobranca
         def self.load_lines(file, options={})
           return nil if file.blank?
 
-          case codigo_banco_do_arquivo(file)
+          codigo_banco = codigo_banco_do_arquivo(file)
+
+          case codigo_banco
           when "237"
             Brcobranca::Retorno::Cnab400::Bradesco.load_lines(file, options)
 
@@ -18,7 +20,6 @@ module Brcobranca
             Brcobranca::Retorno::Cnab400::Itau.load_lines(file, options)
 
           else
-            warn "Banco não encontrado (#{codigo_banco}). Carregando layout antigo padrão (ITAÚ)."
             Brcobranca::Retorno::RetornoCnab400.load_lines(file, options)
           end
         end

--- a/spec/brcobranca/boleto/banco_bradesco_spec.rb
+++ b/spec/brcobranca/boleto/banco_bradesco_spec.rb
@@ -2,26 +2,24 @@
 require 'spec_helper'
 
 RSpec.describe Brcobranca::Boleto::Bradesco do
-  before do
-    @valid_attributes = {
-      especie_documento: 'DM',
-      moeda: '9',
-      data_documento: Date.today,
-      dias_vencimento: 1,
-      aceite: 'S',
-      quantidade: 1,
-      valor: 0.0,
-      local_pagamento: 'Pagável preferencialmente na Rede Bradesco ou Bradesco Expresso',
-      cedente: 'Kivanio Barbosa',
-      documento_cedente: '12345678912',
-      sacado: 'Claudio Pozzebom',
-      sacado_documento: '12345678900',
-      agencia: '4042',
-      conta_corrente: '61900',
-      convenio: 12_387_989,
-      numero_documento: '777700168'
-    }
-  end
+  let(:valid_attributes) {{
+    especie_documento: 'DM',
+    moeda: '9',
+    data_documento: Date.today,
+    dias_vencimento: 1,
+    aceite: 'S',
+    quantidade: 1,
+    valor: 0.0,
+    local_pagamento: 'Pagável preferencialmente na Rede Bradesco ou Bradesco Expresso',
+    cedente: 'Kivanio Barbosa',
+    documento_cedente: '12345678912',
+    sacado: 'Claudio Pozzebom',
+    sacado_documento: '12345678900',
+    agencia: '4042',
+    conta_corrente: '61900',
+    convenio: 12_387_989,
+    numero_documento: '777700168'
+  }}
 
   it 'Criar nova instancia com atributos padrões' do
     boleto_novo = described_class.new
@@ -41,7 +39,7 @@ RSpec.describe Brcobranca::Boleto::Bradesco do
   end
 
   it 'Criar nova instancia com atributos válidos' do
-    boleto_novo = described_class.new(@valid_attributes)
+    boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.banco).to eql('237')
     expect(boleto_novo.especie_documento).to eql('DM')
     expect(boleto_novo.especie).to eql('R$')
@@ -66,13 +64,13 @@ RSpec.describe Brcobranca::Boleto::Bradesco do
   end
 
   it 'Montar código de barras para carteira número 06' do
-    @valid_attributes[:valor] = 2952.95
-    @valid_attributes[:data_documento] = Date.parse('2009-04-30')
-    @valid_attributes[:dias_vencimento] = 0
-    @valid_attributes[:numero_documento] = '75896452'
-    @valid_attributes[:conta_corrente] = '0403005'
-    @valid_attributes[:agencia] = '1172'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:valor] = 2952.95
+    valid_attributes[:data_documento] = Date.parse('2009-04-30')
+    valid_attributes[:dias_vencimento] = 0
+    valid_attributes[:numero_documento] = '75896452'
+    valid_attributes[:conta_corrente] = '0403005'
+    valid_attributes[:agencia] = '1172'
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.codigo_barras_segunda_parte).to eql('1172060007589645204030050')
     expect(boleto_novo.codigo_barras).to eql('23795422300002952951172060007589645204030050')
@@ -80,14 +78,14 @@ RSpec.describe Brcobranca::Boleto::Bradesco do
   end
 
   it 'Montar código de barras para carteira número 03' do
-    @valid_attributes[:valor] = 135.00
-    @valid_attributes[:dias_vencimento] = 1
-    @valid_attributes[:data_documento] = Date.parse('2008-02-01')
-    @valid_attributes[:numero_documento] = '777700168'
-    @valid_attributes[:conta_corrente] = '61900'
-    @valid_attributes[:agencia] = '4042'
-    @valid_attributes[:carteira] = '03'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:valor] = 135.00
+    valid_attributes[:dias_vencimento] = 1
+    valid_attributes[:data_documento] = Date.parse('2008-02-01')
+    valid_attributes[:numero_documento] = '777700168'
+    valid_attributes[:conta_corrente] = '61900'
+    valid_attributes[:agencia] = '4042'
+    valid_attributes[:carteira] = '03'
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.codigo_barras_segunda_parte).to eql('4042030077770016800619000')
     expect(boleto_novo.codigo_barras).to eql('23791377000000135004042030077770016800619000')
@@ -101,7 +99,7 @@ RSpec.describe Brcobranca::Boleto::Bradesco do
   end
 
   it 'Montar nosso_numero_boleto' do
-    boleto_novo = described_class.new(@valid_attributes)
+    boleto_novo = described_class.new(valid_attributes)
 
     boleto_novo.numero_documento = '00000000525'
     boleto_novo.carteira = '06'
@@ -130,7 +128,7 @@ RSpec.describe Brcobranca::Boleto::Bradesco do
   end
 
   it 'Montar agencia_conta_boleto' do
-    boleto_novo = described_class.new(@valid_attributes)
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.agencia_conta_boleto).to eql('4042-8 / 0061900-0')
     boleto_novo.agencia = '0719'
@@ -147,13 +145,13 @@ RSpec.describe Brcobranca::Boleto::Bradesco do
   end
 
   it 'Gerar boleto nos formatos válidos com método to_' do
-    @valid_attributes[:valor] = 2952.95
-    @valid_attributes[:data_documento] = Date.parse('2009-04-30')
-    @valid_attributes[:dias_vencimento] = 0
-    @valid_attributes[:numero_documento] = '75896452'
-    @valid_attributes[:conta_corrente] = '0403005'
-    @valid_attributes[:agencia] = '1172'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:valor] = 2952.95
+    valid_attributes[:data_documento] = Date.parse('2009-04-30')
+    valid_attributes[:dias_vencimento] = 0
+    valid_attributes[:numero_documento] = '75896452'
+    valid_attributes[:conta_corrente] = '0403005'
+    valid_attributes[:agencia] = '1172'
+    boleto_novo = described_class.new(valid_attributes)
 
     %w(pdf jpg tif png).each do |format|
       file_body = boleto_novo.send("to_#{format}".to_sym)
@@ -168,13 +166,13 @@ RSpec.describe Brcobranca::Boleto::Bradesco do
   end
 
   it 'Gerar boleto nos formatos válidos' do
-    @valid_attributes[:valor] = 2952.95
-    @valid_attributes[:data_documento] = Date.parse('2009-04-30')
-    @valid_attributes[:dias_vencimento] = 0
-    @valid_attributes[:numero_documento] = '75896452'
-    @valid_attributes[:conta_corrente] = '0403005'
-    @valid_attributes[:agencia] = '1172'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:valor] = 2952.95
+    valid_attributes[:data_documento] = Date.parse('2009-04-30')
+    valid_attributes[:dias_vencimento] = 0
+    valid_attributes[:numero_documento] = '75896452'
+    valid_attributes[:conta_corrente] = '0403005'
+    valid_attributes[:agencia] = '1172'
+    boleto_novo = described_class.new(valid_attributes)
 
     %w(pdf jpg tif png).each do |format|
       file_body = boleto_novo.to(format)
@@ -186,5 +184,34 @@ RSpec.describe Brcobranca::Boleto::Bradesco do
       expect(File.delete(tmp_file.path)).to eql(1)
       expect(File.exist?(tmp_file.path)).to be_falsey
     end
+  end
+
+  describe "#agencia_dv" do
+    it { expect(described_class.new(agencia: "0255").agencia_dv).to eq(0) }
+    it { expect(described_class.new(agencia: "0943").agencia_dv).to eq(1) }
+    it { expect(described_class.new(agencia: "1467").agencia_dv).to eq(2) }
+    it { expect(described_class.new(agencia: "0794").agencia_dv).to eq(3) }
+    it { expect(described_class.new(agencia: "0155").agencia_dv).to eq(4) }
+    it { expect(described_class.new(agencia: "0650").agencia_dv).to eq(5) }
+    it { expect(described_class.new(agencia: "0199").agencia_dv).to eq(6) }
+    it { expect(described_class.new(agencia: "1425").agencia_dv).to eq(7) }
+    it { expect(described_class.new(agencia: "2839").agencia_dv).to eq(8) }
+    it { expect(described_class.new(agencia: "2332").agencia_dv).to eq(9) }
+    it { expect(described_class.new(agencia: "0121").agencia_dv).to eq("P") }
+  end
+
+  describe "#conta_corrente_dv" do
+    it { expect(described_class.new(conta_corrente: "0325620").conta_corrente_dv).to eq(0) }
+    it { expect(described_class.new(conta_corrente: "0284025").conta_corrente_dv).to eq(1) }
+    it { expect(described_class.new(conta_corrente: "0238069").conta_corrente_dv).to eq(2) }
+    it { expect(described_class.new(conta_corrente: "0135323").conta_corrente_dv).to eq(3) }
+    it { expect(described_class.new(conta_corrente: "0010667").conta_corrente_dv).to eq(4) }
+    it { expect(described_class.new(conta_corrente: "0420571").conta_corrente_dv).to eq(5) }
+    it { expect(described_class.new(conta_corrente: "0510701").conta_corrente_dv).to eq(6) }
+    it { expect(described_class.new(conta_corrente: "0420536").conta_corrente_dv).to eq(7) }
+    it { expect(described_class.new(conta_corrente: "0012500").conta_corrente_dv).to eq(8) }
+    it { expect(described_class.new(conta_corrente: "0010673").conta_corrente_dv).to eq(9) }
+    it { expect(described_class.new(conta_corrente: "0019669").conta_corrente_dv).to eq("P") }
+    it { expect(described_class.new(conta_corrente: "0301357").conta_corrente_dv).to eq("P") }
   end
 end

--- a/spec/brcobranca/retorno/cnab400/base_spec.rb
+++ b/spec/brcobranca/retorno/cnab400/base_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe Brcobranca::Retorno::Cnab400::Base do
 
   describe "#load_lines" do
 
+    it "retorna nil se o arquivo é nil" do
+      expect(Brcobranca::Retorno::Cnab400::Base.load_lines(nil)).to be_nil
+    end
+
     context "Bradesco" do
       let(:nome_arquivo) { "CNAB400BRADESCO.RET" }
 

--- a/spec/support/shared_examples/cnab400.rb
+++ b/spec/support/shared_examples/cnab400.rb
@@ -18,7 +18,7 @@ shared_examples_for 'cnab400' do
         agencia: '12345',
         conta_corrente: '1234567',
         digito_conta: '1',
-        empresa_mae: 'asd',
+        empresa_mae: 'ASD',
         sequencial_remessa: '1',
         codigo_empresa: '123',
         pagamentos: [pagamento] }
@@ -26,7 +26,7 @@ shared_examples_for 'cnab400' do
       {
         portfolio: '17777751042700080112',
         carteira: '1',
-        empresa_mae: 'asd',
+        empresa_mae: 'ASD',
         documento_cedente: '12345678910',
         pagamentos: [pagamento]
       }
@@ -35,7 +35,7 @@ shared_examples_for 'cnab400' do
         agencia: '1234',
         conta_corrente: '12345',
         digito_conta: '1',
-        empresa_mae: 'asd',
+        empresa_mae: 'ASD',
         documento_cedente: '12345678910',
         pagamentos: [pagamento] }
     end


### PR DESCRIPTION
Corrigi o cálculo do dígito verificador do Bradesco da agência e conta-corrente (no boleto aparecia 10 ao invés de "P"), e adicionei os testes para esses casos.

Na Remessa, adicionei a gem unidecoder para transformar toda a informação da Remessa em ASCII (alguns bancos tem problemas para determinar o tamanho da linha se tiver acentos). Também padronizei toda a informação da Remessa pra maiúsculo (upcase).

Também fiz uma pequena melhoria no tratamento dos arquivos lidos pela Remessa::Cnab400::Base. Antes dava uma Exception caso o arquivo fosse inválido.