### PR TITLE
Habilita uso de 2 templates simultâneos

### DIFF
--- a/lib/brcobranca/boleto/base.rb
+++ b/lib/brcobranca/boleto/base.rb
@@ -7,8 +7,10 @@ module Brcobranca
       extend Template::Base
 
       # Configura gerador de arquivo de boleto e código de barras.
-      extend define_template(Brcobranca.configuration.gerador)
-      include define_template(Brcobranca.configuration.gerador)
+      define_template(Brcobranca.configuration.gerador).each do |klass|
+        extend klass
+        include klass
+      end
 
       # Validações do Rails 3
       include ActiveModel::Validations

--- a/lib/brcobranca/boleto/template/base.rb
+++ b/lib/brcobranca/boleto/template/base.rb
@@ -9,11 +9,13 @@ module Brcobranca
         def define_template(template)
           case template
           when :rghost
-            return Brcobranca::Boleto::Template::Rghost
+            return [Brcobranca::Boleto::Template::Rghost]
           when :rghost_carne
-            return Brcobranca::Boleto::Template::RghostCarne
+            return [Brcobranca::Boleto::Template::RghostCarne]
+          when :both
+            return [Brcobranca::Boleto::Template::Rghost, Brcobranca::Boleto::Template::RghostCarne]
           else
-            return Brcobranca::Boleto::Template::Rghost
+            return [Brcobranca::Boleto::Template::Rghost]
           end
         end
       end

--- a/lib/brcobranca/boleto/template/rghost_carne.rb
+++ b/lib/brcobranca/boleto/template/rghost_carne.rb
@@ -30,7 +30,7 @@ module Brcobranca
         # @return [Stream]
         # @see http://wiki.github.com/shairontoledo/rghost/supported-devices-drivers-and-formats Veja mais formatos na documentação do rghost.
         # @see Rghost#modelo_carne Recebe os mesmos parâmetros do Rghost#modelo_carne.
-        def to(formato, options = {})
+        def to_carne(formato, options = {})
           modelo_carne(self, options.merge!(formato: formato))
         end
 
@@ -39,7 +39,7 @@ module Brcobranca
         # @return [Stream]
         # @see http://wiki.github.com/shairontoledo/rghost/supported-devices-drivers-and-formats Veja mais formatos na documentação do rghost.
         # @see Rghost#modelo_carne Recebe os mesmos parâmetros do Rghost#modelo_carne.
-        def lote(boletos, options = {})
+        def lote_carne(boletos, options = {})
           modelo_carne_multipage(boletos, options)
         end
 


### PR DESCRIPTION
Permite usar o rghost e rghost_carne ao mesmo tempo.

```ruby
Brcobranca.setup do |config|
  config.gerador = :both
end
```

Alterações para uso do carnê, os métodos abaixo que antes usavam o mesmo nome nos 2 templates, passam a ter nomes diferentes.
```ruby
.to >> .to_carne
.lote >> .lote_carne
```