### PR TITLE
Add caixa return file support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    brcobranca (6.1.7)
+    brcobranca (6.2.0)
       activemodel (>= 3)
       parseline (~> 1.0.3)
       rghost (= 0.9.5)

--- a/lib/brcobranca.rb
+++ b/lib/brcobranca.rb
@@ -117,8 +117,13 @@ module Brcobranca
   module Retorno
     autoload :Base,            'brcobranca/retorno/base'
     autoload :RetornoCbr643,   'brcobranca/retorno/retorno_cbr643'
-    autoload :RetornoCnab240,  'brcobranca/retorno/retorno_cnab240'
+    autoload :RetornoCnab240,  'brcobranca/retorno/retorno_cnab240' # DEPRECATED
     autoload :RetornoCnab400,  'brcobranca/retorno/retorno_cnab400' # DEPRECATED
+
+    module Cnab240
+      autoload :Base,  'brcobranca/retorno/cnab240/base'
+      autoload :Caixa, 'brcobranca/retorno/cnab240/caixa'
+    end
 
     module Cnab400
       autoload :Base, 'brcobranca/retorno/cnab400/base'

--- a/lib/brcobranca/retorno/cnab240/base.rb
+++ b/lib/brcobranca/retorno/cnab240/base.rb
@@ -1,0 +1,37 @@
+# -*- encoding: utf-8 -*-
+require 'parseline'
+
+module Brcobranca
+  module Retorno
+    module Cnab240
+      class Base < Brcobranca::Retorno::Base
+
+        # Load lines
+        def self.load_lines(file, options={})
+          return nil if file.blank?
+
+          codigo_banco = codigo_banco_do_arquivo(file)
+
+          case codigo_banco
+          when "104"
+            Brcobranca::Retorno::Cnab240::Caixa.load_lines(file, options)
+
+          else
+            Brcobranca::Retorno::RetornoCnab240.load_lines(file, options)
+          end
+        end
+
+        # Codigo do banco lido do arquivo.
+        # Registro Header [0..2]
+        def self.codigo_banco_do_arquivo(file)
+          arquivo = File.open(file, "r")
+          header = arquivo.gets
+          codigo_banco = header.blank? ? nil : header[0..2]
+          arquivo.close
+          codigo_banco
+        end
+
+      end
+    end
+  end
+end

--- a/lib/brcobranca/retorno/cnab240/caixa.rb
+++ b/lib/brcobranca/retorno/cnab240/caixa.rb
@@ -1,0 +1,43 @@
+# -*- encoding: utf-8 -*-
+
+module Brcobranca
+  module Retorno
+    module Cnab240
+      # Formato de Retorno CNAB 240
+      # Baseado em: http://www.caixa.gov.br/downloads/cobranca-caixa-manuais/LEIAUTE_CNAB_240_SIGCB_COBRANCA_CAIXA.pdf
+      class Caixa < Brcobranca::Retorno::RetornoCnab240
+        class Line < Brcobranca::Retorno::RetornoCnab240::Line
+          # Fixed width layout for Caixa
+          fixed_width_layout do |parse|
+            # REGISTRO_T_FIELDS
+            # Not applicable
+            # :cedente_com_dv
+
+            # Same inherited from parent
+            # parse.field :data_vencimento, 73..80
+            # parse.field :valor_titulo, 81..95
+            # parse.field :banco_recebedor, 96..98
+            # parse.field :sequencial, 8..12
+            # parse.field :valor_tarifa, 198..212
+            # parse.field :agencia_com_dv, 17..22
+
+            parse.field :nosso_numero, 39..55
+            parse.field :agencia_recebedora_com_dv, 99..103
+
+            # REGISTRO_U_FIELDS
+
+            # Same inherited from parent
+            # parse.field :desconto_concedito, 32..46
+            # parse.field :valor_abatimento, 47..61
+            # parse.field :iof_desconto, 62..76
+            # parse.field :juros_mora, 17..31
+            # parse.field :valor_recebido, 77..91
+            # parse.field :outras_despesas, 107..121
+            # parse.field :outros_recebimento, 122..136
+            # parse.field :data_credito, 145..152
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/brcobranca/version.rb
+++ b/lib/brcobranca/version.rb
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
 
 module Brcobranca
-  VERSION = '6.1.7'
+  VERSION = '6.2.0'
 end


### PR DESCRIPTION
I put [# DEPRECATED](https://github.com/kasterweb/brcobranca/blob/master/lib/brcobranca.rb#L120) comment in the Cnab240 class to encourage the users to use ``Brcobranca::Retorno::Cnab240::Base.load_lines`` instead of ``Brcobranca::Retorno::RetornoCnab240.load_lines``. Is that right?