### PR TITLE
Rghost carne positions fix

### DIFF
--- a/lib/brcobranca/boleto/template/rghost_carne.rb
+++ b/lib/brcobranca/boleto/template/rghost_carne.rb
@@ -267,7 +267,7 @@ module Brcobranca
 
           # especie
           doc.moveto x: colunas[5], y: linhas[4]
-          doc.show boleto.moeda
+          doc.show boleto.especie
 
           # quantidade
           doc.moveto x: colunas[7], y: linhas[4]

--- a/lib/brcobranca/boleto/template/rghost_carne.rb
+++ b/lib/brcobranca/boleto/template/rghost_carne.rb
@@ -244,7 +244,7 @@ module Brcobranca
 
           # especie doc.
           doc.moveto x: colunas[8], y: linhas[3]
-          doc.show boleto.especie
+          doc.show boleto.especie_documento
 
           # aceite
           doc.moveto x: colunas[9], y: linhas[3]


### PR DESCRIPTION
Algumas informações não estavam corretas no carnê.
1. Espécie de documento, estava mostrando espécie (moeda)
2. Espécie, estava mostrando moeda (o número da moeda - 9 e não o símbolo)