### PR TITLE
Ativa cod_de_ocorrencia no retorno bradesco

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+sudo: false
 rvm:
   - '2.2.3'
   - '2.1.6'

--- a/lib/brcobranca/retorno/base.rb
+++ b/lib/brcobranca/retorno/base.rb
@@ -8,6 +8,7 @@ module Brcobranca
       attr_accessor :cedente_com_dv
       attr_accessor :convenio
       attr_accessor :nosso_numero
+      attr_accessor :cod_de_ocorrencia
       attr_accessor :tipo_cobranca
       attr_accessor :tipo_cobranca_anterior
       attr_accessor :natureza_recebimento

--- a/lib/brcobranca/retorno/cnab400/bradesco.rb
+++ b/lib/brcobranca/retorno/cnab400/bradesco.rb
@@ -43,7 +43,7 @@ module Brcobranca
           # :indicador_de_rateio, 104..104 # indicador de rateio de credito
           # :zeros, 105..106
           # :carteira, 107..107 # de novo?
-          # :cod_de_ocorrencia, 108..109 # código de ocorrencia
+          parse.field :cod_de_ocorrencia, 108..109
           # :data_de_ocorrencia, 110..115 # data de ocorrencia no banco (ddmmaa)
           # :n_do_documento, 116..125 # n umero do documento de cobranca (dupl, np etc)
           # :nosso_numero, 126..133 # confirmacao do numero do titulo no banco

--- a/spec/brcobranca/retorno/cnab400/bradesco_spec.rb
+++ b/spec/brcobranca/retorno/cnab400/bradesco_spec.rb
@@ -34,13 +34,13 @@ RSpec.describe Brcobranca::Retorno::Cnab400::Bradesco do
     expect(pagamento.outros_recebimento).to eql('0000000000000')
     expect(pagamento.data_credito).to eql('150515')
     expect(pagamento.sequencial).to eql('000002')
+    expect(pagamento.cod_de_ocorrencia).to eql('02')
 
     # Campos da classe base que não encontrei a relação com CNAB400
     # parse.field :tipo_cobranca,80..80
     # parse.field :tipo_cobranca_anterior,81..81
     # parse.field :natureza_recebimento,86..87
     # parse.field :convenio,31..37
-    # parse.field :comando,108..109
     # parse.field :juros_desconto,201..213
     # parse.field :iof_desconto,214..226
     # parse.field :desconto_concedito,240..252

--- a/spec/brcobranca/retorno/cnab400/bradesco_spec.rb
+++ b/spec/brcobranca/retorno/cnab400/bradesco_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Brcobranca::Retorno::Cnab400::Bradesco do
     expect(pagamento.outros_recebimento).to eql('0000000000000')
     expect(pagamento.data_credito).to eql('150515')
     expect(pagamento.sequencial).to eql('000002')
-    expect(pagamento.cod_de_ocorrencia).to eql('02')
+    expect(pagamento.cod_de_ocorrencia).to eql("02")
 
     # Campos da classe base que não encontrei a relação com CNAB400
     # parse.field :tipo_cobranca,80..80


### PR DESCRIPTION
Este PR ativa o campo código de ocorrência de retorno. Importante informação para cobrança com registro.

Exemplos de tipos de ocorrências conforme documentação Bradesco:
02..Entrada Confirmada
03..Entrada Rejeitada
06..Liquidação normal