### PR TITLE
Exibir no boleto da caixa se a carteira é registrada(RG) ou sem registro(SR).

### DIFF
--- a/lib/brcobranca/boleto/template/rghost.rb
+++ b/lib/brcobranca/boleto/template/rghost.rb
@@ -201,7 +201,13 @@ module Brcobranca
           if boleto.variacao
             doc.show "#{boleto.carteira}-#{boleto.variacao}"
           else
-            doc.show boleto.carteira
+            if boleto.carteira == "1"
+              doc.show "RG"
+            elsif boleto.carteira == "2"
+              doc.show "SR"
+            else
+              doc.show boleto.carteira
+            end
           end
           doc.moveto x: '6.4 cm', y: '13.5 cm'
           doc.show boleto.especie


### PR DESCRIPTION
Precisei homologar boletos na caixa e quando enviei os boletos eles vão como carteira 1(registrada) e 2(sem registro) porem eles solicitaram que apareça na carteira "RG ou SR" com registro e sem registro respectivamente."
