### PR TITLE
Remessa::Pagamento com validação de uf_sacado para apenas 2 dígitos

### DIFF
--- a/lib/brcobranca/remessa/pagamento.rb
+++ b/lib/brcobranca/remessa/pagamento.rb
@@ -73,6 +73,7 @@ module Brcobranca
       validates_presence_of :nosso_numero, :data_vencimento, :valor,
         :documento_sacado, :nome_sacado, :endereco_sacado,
         :cep_sacado, :cidade_sacado, :uf_sacado, message: 'não pode estar em branco.'
+      validates_length_of :uf_sacado, is: 2, message: 'deve ter 2 dígitos.'
       validates_length_of :cep_sacado, is: 8, message: 'deve ter 8 dígitos.'
       validates_length_of :cod_desconto, is: 1, message: 'deve ter 1 dígito.'
       validates_length_of :especie_titulo, is: 2, message: 'deve ter 2 dígitos.', allow_blank: true

--- a/spec/brcobranca/remessa/pagamento_spec.rb
+++ b/spec/brcobranca/remessa/pagamento_spec.rb
@@ -58,10 +58,18 @@ RSpec.describe Brcobranca::Remessa::Pagamento do
       expect(pagamento.errors.full_messages).to include('Cidade sacado não pode estar em branco.')
     end
 
-    it 'deve ser invalido se nao possuir UF do sacado' do
-      pagamento.uf_sacado = nil
-      expect(pagamento.invalid?).to be true
-      expect(pagamento.errors.full_messages).to include('Uf sacado não pode estar em branco.')
+    context '@uf_sacado' do
+      it 'deve ser invalido se nao possuir UF do sacado' do
+        pagamento.uf_sacado = nil
+        expect(pagamento.invalid?).to be true
+        expect(pagamento.errors.full_messages).to include('Uf sacado não pode estar em branco.')
+      end
+
+      it 'deve ser invalido se UF do sacado for maior que 2 caracteres' do
+        pagamento.uf_sacado = "Santa Catarina"
+        expect(pagamento.invalid?).to be true
+        expect(pagamento.errors.full_messages).to include('Uf sacado deve ter 2 dígitos.')
+      end
     end
 
     context '@cep' do


### PR DESCRIPTION
Corrige https://github.com/kivanio/brcobranca/issues/123