### PR TITLE
Alinhamento das informações do boleto a direita

### DIFF
--- a/lib/brcobranca/boleto/template/rghost.rb
+++ b/lib/brcobranca/boleto/template/rghost.rb
@@ -151,10 +151,10 @@ module Brcobranca
           doc.show "#{boleto.documento_cedente.formata_documento}"
           doc.moveto x: '12 cm', y: '22.2 cm'
           doc.show boleto.data_vencimento.to_s_br
-          doc.moveto x: '16.5 cm', y: '23 cm'
-          doc.show boleto.nosso_numero_boleto
-          doc.moveto x: '16.5 cm', y: '22.2 cm'
-          doc.show boleto.valor_documento.to_currency
+          doc.moveto x: '20.3 cm', y: '23 cm'
+          doc.show boleto.nosso_numero_boleto, align: :show_right
+          doc.moveto x: '20.3 cm', y: '22.2 cm'
+          doc.show boleto.valor_documento.to_currency, align: :show_right
           doc.moveto x: '1.5 cm', y: '20.9 cm'
           doc.show "#{boleto.sacado} - #{boleto.sacado_documento.formata_documento}"
           doc.moveto x: '1.5 cm', y: '20.6 cm'
@@ -173,8 +173,8 @@ module Brcobranca
           doc.show boleto.codigo_barras.linha_digitavel, tag: :grande
           doc.moveto x: '0.7 cm', y: '16 cm'
           doc.show boleto.local_pagamento
-          doc.moveto x: '16.5 cm', y: '16 cm'
-          doc.show boleto.data_vencimento.to_s_br if boleto.data_vencimento
+          doc.moveto x: '20.3 cm', y: '16 cm'
+          doc.show boleto.data_vencimento.to_s_br, align: :show_right if boleto.data_vencimento
           doc.moveto x: '0.7 cm', y: '15.2 cm'
           if boleto.cedente_endereco
             doc.show boleto.cedente_endereco
@@ -183,8 +183,8 @@ module Brcobranca
           else
             doc.show boleto.cedente
           end
-          doc.moveto x: '16.5 cm', y: '15.2 cm'
-          doc.show boleto.agencia_conta_boleto
+          doc.moveto x: '20.3 cm', y: '15.2 cm'
+          doc.show boleto.agencia_conta_boleto, align: :show_right
           doc.moveto x: '0.7 cm', y: '14.4 cm'
           doc.show boleto.data_documento.to_s_br if boleto.data_documento
           doc.moveto x: '4.2 cm', y: '14.4 cm'
@@ -195,8 +195,8 @@ module Brcobranca
           doc.show boleto.aceite
           doc.moveto x: '13 cm', y: '14.4 cm'
           doc.show boleto.data_processamento.to_s_br if boleto.data_processamento
-          doc.moveto x: '16.5 cm', y: '14.4 cm'
-          doc.show boleto.nosso_numero_boleto
+          doc.moveto x: '20.3 cm', y: '14.4 cm'
+          doc.show boleto.nosso_numero_boleto, align: :show_right
           doc.moveto x: '4.4 cm', y: '13.5 cm'
           if boleto.variacao
             doc.show "#{boleto.carteira}-#{boleto.variacao}"
@@ -209,8 +209,8 @@ module Brcobranca
           # doc.show boleto.quantidade
           # doc.moveto :x => '11 cm' , :y => '13.5 cm'
           # doc.show boleto.valor.to_currency
-          doc.moveto x: '16.5 cm', y: '13.5 cm'
-          doc.show boleto.valor_documento.to_currency
+          doc.moveto x: '20.3 cm', y: '13.5 cm'
+          doc.show boleto.valor_documento.to_currency, align: :show_right
           doc.moveto x: '0.7 cm', y: '12.7 cm'
           doc.show boleto.instrucao1
           doc.moveto x: '0.7 cm', y: '12.3 cm'


### PR DESCRIPTION
Esse PR faz o alinhamento dos valores à direita.

Foi um pedido da homologação do Itaú.

Segue como fica:

<img width="227" alt="screenshot 2016-07-01 01 22 43" src="https://cloud.githubusercontent.com/assets/9155/16511788/69a3b988-3f2a-11e6-9a16-9626147f14e9.png">
