### PR TITLE
Adds demonstrativo fields to Brcobranca::Boleto::Base

### DIFF
--- a/lib/brcobranca/boleto/base.rb
+++ b/lib/brcobranca/boleto/base.rb
@@ -50,6 +50,12 @@ module Brcobranca
       # <b>OPCIONAL</b>: Código utilizado para identificar o tipo de serviço cobrado
       attr_accessor :codigo_servico
       # <b>OPCIONAL</b>: Utilizado para mostrar alguma informação ao sacado
+      attr_accessor :demonstrativo1
+      # <b>OPCIONAL</b>: Utilizado para mostrar alguma informação ao sacado
+      attr_accessor :demonstrativo2
+      # <b>OPCIONAL</b>: Utilizado para mostrar alguma informação ao sacado
+      attr_accessor :demonstrativo3
+      # <b>OPCIONAL</b>: Utilizado para mostrar alguma informação ao sacado
       attr_accessor :instrucao1
       # <b>OPCIONAL</b>: Utilizado para mostrar alguma informação ao sacado
       attr_accessor :instrucao2

--- a/lib/brcobranca/boleto/template/rghost.rb
+++ b/lib/brcobranca/boleto/template/rghost.rb
@@ -159,6 +159,12 @@ module Brcobranca
           doc.show "#{boleto.sacado} - #{boleto.sacado_documento.formata_documento}"
           doc.moveto x: '1.5 cm', y: '20.6 cm'
           doc.show "#{boleto.sacado_endereco}"
+          doc.moveto x: '0.7 cm', y: '19.8 cm'
+          doc.show boleto.demonstrativo1
+          doc.moveto x: '0.7 cm', y: '19.4 cm'
+          doc.show boleto.demonstrativo2
+          doc.moveto x: '0.7 cm', y: '19.0 cm'
+          doc.show boleto.demonstrativo3
           # FIM Primeira parte do BOLETO
         end
 


### PR DESCRIPTION
This PR adds new `demonstrativo` fields to Brcobranca::Boleto::Base as like `instrucao` fields. The attributes are:

```
demonstrativo1
demonstrativo2
demonstrativo3
```

I think this feature is very useful for description of bank billet.