### PR TITLE
Update base.rb

### DIFF
--- a/lib/brcobranca/boleto/base.rb
+++ b/lib/brcobranca/boleto/base.rb
@@ -81,7 +81,7 @@ module Brcobranca
       attr_accessor :cedente_endereco
 
       # Validações
-      validates_presence_of :agencia, :conta_corrente, :moeda, :especie_documento, :especie, :aceite, :numero_documento, message: 'não pode estar em branco.'
+      validates_presence_of :agencia, :conta_corrente, :moeda, :especie_documento, :especie, :aceite, :numero_documento, :sacado, :sacado_documento, message: 'não pode estar em branco.'
       validates_numericality_of :convenio, :agencia, :conta_corrente, :numero_documento, message: 'não é um número.', allow_nil: true
 
       # Nova instancia da classe Base


### PR DESCRIPTION
Estou estudando e testando a GEM, no base.rb diz que o atributo é obrigatório, mas não há validação de presença.
Há boletos que não tem a necessidade de informar o sacado?