### PR TITLE
Obrigatoriedade do nome e documento do sacado

### DIFF
--- a/lib/brcobranca/boleto/base.rb
+++ b/lib/brcobranca/boleto/base.rb
@@ -81,7 +81,7 @@ module Brcobranca
       attr_accessor :cedente_endereco
 
       # Validações
-      validates_presence_of :agencia, :conta_corrente, :moeda, :especie_documento, :especie, :aceite, :numero_documento, message: 'não pode estar em branco.'
+      validates_presence_of :agencia, :conta_corrente, :moeda, :especie_documento, :especie, :aceite, :numero_documento, :sacado, :sacado_documento, message: 'não pode estar em branco.'
       validates_numericality_of :convenio, :agencia, :conta_corrente, :numero_documento, message: 'não é um número.', allow_nil: true
 
       # Nova instancia da classe Base

--- a/spec/brcobranca/boleto/banco_nordeste_spec.rb
+++ b/spec/brcobranca/boleto/banco_nordeste_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Brcobranca::Boleto::BancoNordeste do #:nodoc:[all]
   it 'Não permitir gerar boleto com atributos inválido' do
     boleto_novo = described_class.new
     expect { boleto_novo.codigo_barras }.to raise_error(Brcobranca::BoletoInvalido)
-    expect(boleto_novo.errors.count).to eql(3)
+    expect(boleto_novo.errors.count).to eql(5)
   end
 
   it 'Montar nosso_numero_dv' do

--- a/spec/brcobranca/boleto/banestes_spec.rb
+++ b/spec/brcobranca/boleto/banestes_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Brcobranca::Boleto::Banestes do #:nodoc:[all]
   it "Não permitir gerar boleto com atributos inválido" do
     boleto_novo = described_class.new
     expect { boleto_novo.codigo_barras }.to raise_error(Brcobranca::BoletoInvalido)
-    expect(boleto_novo.errors.count).to eql(3)
+    expect(boleto_novo.errors.count).to eql(5)
   end
 
   it "Montar agencia_conta_boleto" do

--- a/spec/brcobranca/boleto/bradesco_spec.rb
+++ b/spec/brcobranca/boleto/bradesco_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Brcobranca::Boleto::Bradesco do
   it 'Não permitir gerar boleto com atributos inválido' do
     boleto_novo = described_class.new
     expect { boleto_novo.codigo_barras }.to raise_error(Brcobranca::BoletoInvalido)
-    expect(boleto_novo.errors.count).to eql(3)
+    expect(boleto_novo.errors.count).to eql(5)
   end
 
   it 'Montar nosso_numero_boleto' do

--- a/spec/brcobranca/boleto/hsbc_spec.rb
+++ b/spec/brcobranca/boleto/hsbc_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Brcobranca::Boleto::Hsbc do
   it 'Não permitir gerar boleto com atributos inválido' do
     boleto_novo = described_class.new
     expect { boleto_novo.codigo_barras }.to raise_error(Brcobranca::BoletoInvalido)
-    expect(boleto_novo.errors.count).to eql(3)
+    expect(boleto_novo.errors.count).to eql(5)
   end
 
   it 'Montar nosso número' do

--- a/spec/brcobranca/boleto/itau_spec.rb
+++ b/spec/brcobranca/boleto/itau_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe Brcobranca::Boleto::Itau do
   it 'Não permitir gerar boleto com atributos inválido' do
     boleto_novo = described_class.new
     expect { boleto_novo.codigo_barras }.to raise_error(Brcobranca::BoletoInvalido)
-    expect(boleto_novo.errors.count).to eql(3)
+    expect(boleto_novo.errors.count).to eql(5)
   end
 
   it 'Montar agencia_conta_corrente_dv' do

--- a/spec/brcobranca/boleto/santander_spec.rb
+++ b/spec/brcobranca/boleto/santander_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Brcobranca::Boleto::Santander do
   it 'Não permitir gerar boleto com atributos inválido' do
     boleto_novo = described_class.new
     expect { boleto_novo.codigo_barras }.to raise_error(Brcobranca::BoletoInvalido)
-    expect(boleto_novo.errors.count).to eql(3)
+    expect(boleto_novo.errors.count).to eql(5)
   end
 
   it 'Montar nosso_numero_dv' do

--- a/spec/brcobranca/boleto/sicoob_spec.rb
+++ b/spec/brcobranca/boleto/sicoob_spec.rb
@@ -129,13 +129,30 @@ RSpec.describe Brcobranca::Boleto::Sicoob do #:nodoc:[all]
   end
 
 
-  it 'Montar código de barras' do
+  it 'Montar código de barras modalidade 01' do
     boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.codigo_barras.linha_digitavel).to eql('75691.43279 01022.938508 00000.240010 2 67080000005000')
     expect(boleto_novo.codigo_barras_segunda_parte).to eql('1432701022938500000024001')
     expect(boleto_novo.codigo_barras_segunda_parte.size).to eql(25)
 
+  end
+  
+  it 'Montar código de barras modalidade 05' do
+    valid_attributes[:data_documento] = Date.parse("2017-04-15")
+    valid_attributes[:data_vencimento] = Date.parse("2017-04-15")
+    valid_attributes[:valor] = 235.00
+    valid_attributes[:agencia] = "4134"
+    valid_attributes[:conta_corrente] = "10333"
+    valid_attributes[:convenio] = "148180"
+    valid_attributes[:numero_documento] = "110"
+    valid_attributes[:variacao] = "05"
+
+    boleto_novo = described_class.new(valid_attributes)
+
+    expect(boleto_novo.codigo_barras.linha_digitavel).to eql('75691.41349 05014.818008 00011.040011 4 71300000023500')
+    expect(boleto_novo.codigo_barras_segunda_parte).to eql('1413405014818000001104001')
+    expect(boleto_novo.codigo_barras_segunda_parte.size).to eql(25)
   end
 
   describe 'Busca logotipo do banco' do

--- a/spec/brcobranca/boleto/sicoob_spec.rb
+++ b/spec/brcobranca/boleto/sicoob_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Brcobranca::Boleto::Sicoob do #:nodoc:[all]
   it "Não permitir gerar boleto com atributos inválido" do
     boleto_novo = described_class.new
     expect { boleto_novo.codigo_barras }.to raise_error(Brcobranca::BoletoInvalido)
-    expect(boleto_novo.errors.count).to eql(3)
+    expect(boleto_novo.errors.count).to eql(5)
   end
 
   it "Montar agencia_conta_boleto" do
@@ -82,23 +82,23 @@ RSpec.describe Brcobranca::Boleto::Sicoob do #:nodoc:[all]
     valid_attributes[:numero_documento] = "2"
     boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.nosso_numero_dv).to eql(4)
-    
+
     valid_attributes[:numero_documento] = "3"
     boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.nosso_numero_dv).to eql(1)
-    
+
     valid_attributes[:numero_documento] = "4"
     boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.nosso_numero_dv).to eql(9)
-    
+
     valid_attributes[:numero_documento] = "5"
     boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.nosso_numero_dv).to eql(6)
-    
+
     valid_attributes[:numero_documento] = "6"
     boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.nosso_numero_dv).to eql(3)
-    
+
     valid_attributes[:numero_documento] = "7"
     boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.nosso_numero_dv).to eql(0)
@@ -106,23 +106,23 @@ RSpec.describe Brcobranca::Boleto::Sicoob do #:nodoc:[all]
     valid_attributes[:numero_documento] = "8"
     boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.nosso_numero_dv).to eql(8)
-    
+
     valid_attributes[:numero_documento] = "9"
     boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.nosso_numero_dv).to eql(5)
-    
+
     valid_attributes[:numero_documento] = "10"
     boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.nosso_numero_dv).to eql(3)
-    
+
     valid_attributes[:numero_documento] = "11"
     boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.nosso_numero_dv).to eql(0)
-    
+
     valid_attributes[:numero_documento] = "12"
     boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.nosso_numero_dv).to eql(8)
-    
+
     valid_attributes[:numero_documento] = "13"
     boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.nosso_numero_dv).to eql(5)
@@ -137,7 +137,7 @@ RSpec.describe Brcobranca::Boleto::Sicoob do #:nodoc:[all]
     expect(boleto_novo.codigo_barras_segunda_parte.size).to eql(25)
 
   end
-  
+
   it 'Montar código de barras modalidade 05' do
     valid_attributes[:data_documento] = Date.parse("2017-04-15")
     valid_attributes[:data_vencimento] = Date.parse("2017-04-15")

--- a/spec/brcobranca/boleto/sicredi_spec.rb
+++ b/spec/brcobranca/boleto/sicredi_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Brcobranca::Boleto::Sicredi do
   it 'Não permitir gerar boleto com atributos inválido' do
     boleto_novo = described_class.new
     expect { boleto_novo.codigo_barras }.to raise_error(Brcobranca::BoletoInvalido)
-    expect(boleto_novo.errors.count).to eql(4)
+    expect(boleto_novo.errors.count).to eql(6)
   end
 
   it 'Montar nosso_numero_boleto' do

--- a/spec/brcobranca/boleto/unicred_spec.rb
+++ b/spec/brcobranca/boleto/unicred_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Brcobranca::Boleto::Unicred do
   it 'Não permitir gerar boleto com atributos inválido' do
     boleto_novo = described_class.new
     expect { boleto_novo.codigo_barras }.to raise_error(Brcobranca::BoletoInvalido)
-    expect(boleto_novo.errors.count).to eql(4)
+    expect(boleto_novo.errors.count).to eql(6)
   end
 
   it 'Montar nosso_numero_boleto' do


### PR DESCRIPTION
Adicionada a validação em Brcobranca::Boleto::Base e alterado os testes para esperar mais 2 erros de validação.