### PR TITLE
Boletos para CAIXA. Imprimir RG ou SR no boleto

### DIFF
--- a/lib/brcobranca/boleto/base.rb
+++ b/lib/brcobranca/boleto/base.rb
@@ -23,6 +23,8 @@ module Brcobranca
       # <b>REQUERIDO</b>: Carteira utilizada
       attr_accessor :carteira
       # <b>OPCIONAL</b>: Variacao da carteira(opcional para a maioria dos bancos)
+      attr_accessor :carteira_label
+      # <b>OPCIONAL</b>: Rótulo da Carteira, RG ou SR, somente para impressão no boleto.
       attr_accessor :variacao
       # <b>OPCIONAL</b>: Data de processamento do boleto, geralmente igual a data_documento
       attr_accessor :data_processamento

--- a/lib/brcobranca/boleto/caixa.rb
+++ b/lib/brcobranca/boleto/caixa.rb
@@ -14,7 +14,6 @@ module Brcobranca
       # Validações
       # Modalidade/Carteira de Cobrança (1-Registrada | 2-Sem Registro)
       validates_length_of :carteira, is: 1, message: 'deve possuir 1 dígitos.'
-      #validates_length_of :carteira_label, is: 2, message: 'deve possuir 2 dígitos.' # "RG"-Registrada | "SR"-Sem Registro
       # Emissão do boleto (4-Beneficiário)
       validates_length_of :emissao, is: 1, message: 'deve possuir 1 dígitos.'
       validates_length_of :convenio, is: 6, message: 'deve possuir 6 dígitos.'
@@ -24,7 +23,8 @@ module Brcobranca
       # @param (see Brcobranca::Boleto::Base#initialize)
       def initialize(campos = {})
         campos = {
-          carteira: '2',
+          carteira: '1',
+          carteira_label: 'RG',
           emissao: '4'
         }.merge!(campos)
 

--- a/lib/brcobranca/boleto/caixa.rb
+++ b/lib/brcobranca/boleto/caixa.rb
@@ -10,10 +10,11 @@ module Brcobranca
     class Caixa < Base # Caixa
       # <b>REQUERIDO</b>: Emissão do boleto
       attr_accessor :emissao
-
+  
       # Validações
       # Modalidade/Carteira de Cobrança (1-Registrada | 2-Sem Registro)
       validates_length_of :carteira, is: 1, message: 'deve possuir 1 dígitos.'
+      #validates_length_of :carteira_label, is: 2, message: 'deve possuir 2 dígitos.' # "RG"-Registrada | "SR"-Sem Registro
       # Emissão do boleto (4-Beneficiário)
       validates_length_of :emissao, is: 1, message: 'deve possuir 1 dígitos.'
       validates_length_of :convenio, is: 6, message: 'deve possuir 6 dígitos.'

--- a/lib/brcobranca/boleto/template/rghost.rb
+++ b/lib/brcobranca/boleto/template/rghost.rb
@@ -205,10 +205,14 @@ module Brcobranca
           doc.moveto x: '20.3 cm', y: '14.4 cm'
           doc.show boleto.nosso_numero_boleto, align: :show_right
           doc.moveto x: '4.4 cm', y: '13.5 cm'
-          if boleto.variacao
-            doc.show "#{boleto.carteira}-#{boleto.variacao}"
+          if boleto.carteira_label
+            doc.show boleto.carteira_label
           else
-            doc.show boleto.carteira
+            if boleto.variacao
+              doc.show "#{boleto.carteira}-#{boleto.variacao}"
+            else
+              doc.show boleto.carteira
+            end
           end
           doc.moveto x: '6.4 cm', y: '13.5 cm'
           doc.show boleto.especie

--- a/spec/brcobranca/boleto/caixa_spec.rb
+++ b/spec/brcobranca/boleto/caixa_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Brcobranca::Boleto::Caixa do #:nodoc:[all]
     expect(boleto_novo.valor_documento).to be(0.0)
     expect(boleto_novo.local_pagamento).to eql('PREFERENCIALMENTE NAS CASAS LOTÉRICAS ATÉ O VALOR LIMITE')
     expect(boleto_novo.codigo_servico).to be_falsey
-    expect(boleto_novo.carteira).to eql('2')
+    expect(boleto_novo.carteira).to eql('1')
     expect(boleto_novo.emissao).to eql('4')
   end
 
@@ -55,7 +55,7 @@ RSpec.describe Brcobranca::Boleto::Caixa do #:nodoc:[all]
     boleto_novo = described_class.new @valid_attributes
     expect { boleto_novo.codigo_barras }.not_to raise_error
     expect(boleto_novo.codigo_barras_segunda_parte).not_to be_blank
-    expect(boleto_novo.codigo_barras_segunda_parte).to eql('2452740000200040000000010')
+    expect(boleto_novo.codigo_barras_segunda_parte).to eql('2452740000200040000000017')
   end
 
   it 'Não permitir gerar boleto com atributos inválidos' do
@@ -103,7 +103,7 @@ RSpec.describe Brcobranca::Boleto::Caixa do #:nodoc:[all]
 
   it 'Montar nosso_numero_boleto' do
     boleto_novo = described_class.new @valid_attributes
-    expect(boleto_novo.nosso_numero_boleto).to eq('24000000000000001-2')
+    expect(boleto_novo.nosso_numero_boleto).to eq('24000000000000001-4')
   end
 
   it 'Montar agencia_conta_boleto' do

--- a/spec/brcobranca/boleto/caixa_spec.rb
+++ b/spec/brcobranca/boleto/caixa_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Brcobranca::Boleto::Caixa do #:nodoc:[all]
     boleto_novo = described_class.new @valid_attributes
     expect { boleto_novo.codigo_barras }.not_to raise_error
     expect(boleto_novo.codigo_barras_segunda_parte).not_to be_blank
-    expect(boleto_novo.codigo_barras_segunda_parte).to eql('2452740000200040000000017')
+    expect(boleto_novo.codigo_barras_segunda_parte).to eql('2452740000100040000000017')
   end
 
   it 'Não permitir gerar boleto com atributos inválidos' do
@@ -103,7 +103,7 @@ RSpec.describe Brcobranca::Boleto::Caixa do #:nodoc:[all]
 
   it 'Montar nosso_numero_boleto' do
     boleto_novo = described_class.new @valid_attributes
-    expect(boleto_novo.nosso_numero_boleto).to eq('24000000000000001-4')
+    expect(boleto_novo.nosso_numero_boleto).to eq('14000000000000001-4')
   end
 
   it 'Montar agencia_conta_boleto' do


### PR DESCRIPTION
Boletos para CAIXA, outros bancos não testei;
Alteração na LABEL "Carteira" no layout do boleto para imprimir SR ou RG;
O attr :carteira não sofreu alteração para manter a integridade da GEM, permanecendo 1|2
Uso:
@boleto.carteira_label = "RG"