### PR TITLE
Suporte a juros, multa, leitura de retorno de bancos cnab400 e código motivo em retorno

### DIFF
--- a/lib/brcobranca.rb
+++ b/lib/brcobranca.rb
@@ -134,12 +134,15 @@ module Brcobranca
 
     module Cnab400
       autoload :Base, 'brcobranca/retorno/cnab400/base'
+      autoload :BancoBrasil, 'brcobranca/retorno/cnab400/banco_brasil'
       autoload :Bradesco, 'brcobranca/retorno/cnab400/bradesco'
+      autoload :Santander, 'brcobranca/retorno/cnab400/santander'
       autoload :Itau, 'brcobranca/retorno/cnab400/itau'
     end
 
     module Cnab240
       autoload :Base, 'brcobranca/retorno/cnab240/base'
+      autoload :Caixa, 'brcobranca/retorno/cnab240/caixa'
       autoload :Sicoob, 'brcobranca/retorno/cnab240/sicoob'
       autoload :Santander, 'brcobranca/retorno/cnab240/santander'
     end

--- a/lib/brcobranca.rb
+++ b/lib/brcobranca.rb
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
-#
+# frozen_string_literal: true
+
 require 'active_model'
 require 'active_support/core_ext/date/calculations'
 require 'active_support/core_ext/time/calculations'

--- a/lib/brcobranca/boleto/santander.rb
+++ b/lib/brcobranca/boleto/santander.rb
@@ -5,6 +5,7 @@
 module Brcobranca
   module Boleto
     class Santander < Base # Banco Santander
+      validates_presence_of :convenio
       validates_length_of :agencia, maximum: 4, message: 'deve ser menor ou igual a 4 dígitos.'
       validates_length_of :convenio, maximum: 7, message: 'deve ser menor ou igual a 7 dígitos.'
       validates_length_of :numero_documento, maximum: 7, message: 'deve ser menor ou igual a 7 dígitos.'

--- a/lib/brcobranca/remessa/cnab240/base.rb
+++ b/lib/brcobranca/remessa/cnab240/base.rb
@@ -230,29 +230,29 @@ module Brcobranca
         #
         def monta_segmento_r(pagamento, nro_lote, sequencial)
           return false if pagamento.codigo_multa == '0'
-          segmento_q = ''                                                 # CAMPO                                TAMANHO
-          segmento_q << cod_banco                                         # codigo banco                         3
-          segmento_q << nro_lote.to_s.rjust(4, '0')                       # lote de servico                      4
-          segmento_q << '3'                                               # tipo de registro                     1
-          segmento_q << sequencial.to_s.rjust(5, '0')                     # num. sequencial do registro no lote  5
-          segmento_q << 'R'                                               # cod. segmento                        1
-          segmento_q << ' '                                               # uso exclusivo                        1
-          segmento_q << '01'                                              # cod. movimento remessa               2
-          segmento_q << pagamento.cod_desconto                            # Código do Desconto 2                 1
-          segmento_q << pagamento.formata_data_desconto('%d%m%Y')         # Data do Desconto 2                   8
-          segmento_q << pagamento.formata_valor_desconto(15)              # Valor/Percentual a ser Concedido     15
-          segmento_q << pagamento.cod_desconto                            # Código do Desconto 3                 1
-          segmento_q << pagamento.formata_data_segundo_desconto('%d%m%Y') # Data do Desconto 3                   8
-          segmento_q << pagamento.formata_valor_desconto(15)              # Valor/Percentual a Ser Concedido     15
-          segmento_q << pagamento.codigo_multa                            # Código da Multa                      1
-          segmento_q << pagamento.formata_data_multa('%d%m%Y')            # Data da Multa                        8
-          segmento_q << pagamento.formata_valor_multa(15)                 # Valor/Percentual a Ser Aplicado      15
-          segmento_q << ''.rjust(10, ' ')                                 # Informação ao Pagador                10
-          segmento_q << ''.rjust(40, ' ')                                 # Mensagem 3                           40
-          segmento_q << ''.rjust(40, ' ')                                 # Mensagem 4                           40
-          segmento_q << ''.rjust(50, ' ')                                 # Uso Exclusivo CAIXA                  50
-          segmento_q << ''.rjust(11, ' ')                                 # CNAB                                 11
-          segmento_q
+          segmento_r = ''                                                 # CAMPO                                TAMANHO
+          segmento_r << cod_banco                                         # codigo banco                         3
+          segmento_r << nro_lote.to_s.rjust(4, '0')                       # lote de servico                      4
+          segmento_r << '3'                                               # tipo de registro                     1
+          segmento_r << sequencial.to_s.rjust(5, '0')                     # num. sequencial do registro no lote  5
+          segmento_r << 'R'                                               # cod. segmento                        1
+          segmento_r << ' '                                               # uso exclusivo                        1
+          segmento_r << '01'                                              # cod. movimento remessa               2
+          segmento_r << pagamento.cod_desconto                            # Código do Desconto 2                 1
+          segmento_r << pagamento.formata_data_desconto('%d%m%Y')         # Data do Desconto 2                   8
+          segmento_r << pagamento.formata_valor_desconto(15)              # Valor/Percentual a ser Concedido     15
+          segmento_r << pagamento.cod_desconto                            # Código do Desconto 3                 1
+          segmento_r << pagamento.formata_data_segundo_desconto('%d%m%Y') # Data do Desconto 3                   8
+          segmento_r << pagamento.formata_valor_desconto(15)              # Valor/Percentual a Ser Concedido     15
+          segmento_r << pagamento.codigo_multa                            # Código da Multa                      1
+          segmento_r << pagamento.formata_data_multa('%d%m%Y')            # Data da Multa                        8
+          segmento_r << pagamento.formata_valor_multa(15)                 # Valor/Percentual a Ser Aplicado      15
+          segmento_r << ''.rjust(10, ' ')                                 # Informação ao Pagador                10
+          segmento_r << ''.rjust(40, ' ')                                 # Mensagem 3                           40
+          segmento_r << ''.rjust(40, ' ')                                 # Mensagem 4                           40
+          segmento_r << ''.rjust(50, ' ')                                 # Uso Exclusivo CAIXA                  50
+          segmento_r << ''.rjust(11, ' ')                                 # CNAB                                 11
+          segmento_r
         end
 
         # Monta o registro trailer do lote

--- a/lib/brcobranca/remessa/cnab240/base.rb
+++ b/lib/brcobranca/remessa/cnab240/base.rb
@@ -68,27 +68,27 @@ module Brcobranca
         # @return [String]
         #
         def monta_header_arquivo
-          header_arquivo = '' # CAMPO                         TAMANHO
-          header_arquivo << cod_banco # codigo do banco               3
-          header_arquivo << '0000' # lote do servico               4
-          header_arquivo << '0' # tipo de registro              1
-          header_arquivo << ''.rjust(9, ' ') # uso exclusivo FEBRABAN        9
+          header_arquivo = ''                                                            # CAMPO                         TAMANHO
+          header_arquivo << cod_banco                                                    # codigo do banco               3
+          header_arquivo << '0000'                                                       # lote do servico               4
+          header_arquivo << '0'                                                          # tipo de registro              1
+          header_arquivo << ''.rjust(9, ' ')                                             # uso exclusivo FEBRABAN        9
           header_arquivo << Brcobranca::Util::Empresa.new(documento_cedente, false).tipo # tipo inscricao                1
-          header_arquivo << documento_cedente.to_s.rjust(14, '0') # numero de inscricao           14
-          header_arquivo << codigo_convenio # codigo do convenio no banco   20
-          header_arquivo << info_conta # informacoes da conta          20
-          header_arquivo << empresa_mae.format_size(30) # nome da empresa               30
-          header_arquivo << nome_banco.format_size(30) # nome do banco                 30
-          header_arquivo << ''.rjust(10, ' ') # uso exclusivo FEBRABAN        10
-          header_arquivo << '1' # codigo remessa                1
-          header_arquivo << data_geracao # data geracao                  8
-          header_arquivo << hora_geracao # hora geracao                  6
-          header_arquivo << sequencial_remessa.to_s.rjust(6, '0') # numero seq. arquivo           6
-          header_arquivo << versao_layout_arquivo # num. versao arquivo           3
-          header_arquivo << ''.rjust(5, '0') # densidade gravacao            5
-          header_arquivo << ''.rjust(20, '0') # uso exclusivo                 20
-          header_arquivo << ''.rjust(20, '0') # uso exclusivo                 20
-          header_arquivo << complemento_header # complemento do arquivo        29
+          header_arquivo << documento_cedente.to_s.rjust(14, '0')                        # numero de inscricao           14
+          header_arquivo << codigo_convenio                                              # codigo do convenio no banco   20
+          header_arquivo << info_conta                                                   # informacoes da conta          20
+          header_arquivo << empresa_mae.format_size(30)                                  # nome da empresa               30
+          header_arquivo << nome_banco.format_size(30)                                   # nome do banco                 30
+          header_arquivo << ''.rjust(10, ' ')                                            # uso exclusivo FEBRABAN        10
+          header_arquivo << '1'                                                          # codigo remessa                1
+          header_arquivo << data_geracao                                                 # data geracao                  8
+          header_arquivo << hora_geracao                                                 # hora geracao                  6
+          header_arquivo << sequencial_remessa.to_s.rjust(6, '0')                        # numero seq. arquivo           6
+          header_arquivo << versao_layout_arquivo                                        # num. versao arquivo           3
+          header_arquivo << ''.rjust(5, '0')                                             # densidade gravacao            5
+          header_arquivo << ''.rjust(20, '0')                                            # uso exclusivo                 20
+          header_arquivo << ''.rjust(20, '0')                                            # uso exclusivo                 20
+          header_arquivo << complemento_header                                           # complemento do arquivo        29
           header_arquivo
         end
 
@@ -100,26 +100,26 @@ module Brcobranca
         # @return [String]
         #
         def monta_header_lote(nro_lote)
-          header_lote = '' # CAMPO                   TAMANHO
-          header_lote << cod_banco # codigo banco            3
-          header_lote << nro_lote.to_s.rjust(4, '0') # lote servico            4
-          header_lote << '1' # tipo de registro        1
-          header_lote << 'R' # tipo de operacao        1
-          header_lote << '01' # tipo de servico         2
-          header_lote << '  ' # uso exclusivo           2
-          header_lote << versao_layout_lote # num.versao layout lote  3
-          header_lote << ' ' # uso exclusivo           1
+          header_lote = ''                                                            # CAMPO                   TAMANHO
+          header_lote << cod_banco                                                    # codigo banco            3
+          header_lote << nro_lote.to_s.rjust(4, '0')                                  # lote servico            4
+          header_lote << '1'                                                          # tipo de registro        1
+          header_lote << 'R'                                                          # tipo de operacao        1
+          header_lote << '01'                                                         # tipo de servico         2
+          header_lote << '  '                                                         # uso exclusivo           2
+          header_lote << versao_layout_lote                                           # num.versao layout lote  3
+          header_lote << ' '                                                          # uso exclusivo           1
           header_lote << Brcobranca::Util::Empresa.new(documento_cedente, false).tipo # tipo de inscricao       1
-          header_lote << documento_cedente.to_s.rjust(15, '0') # inscricao cedente       15
-          header_lote << convenio_lote # codigo do convenio      20
-          header_lote << info_conta # informacoes conta       20
-          header_lote << empresa_mae.format_size(30) # nome empresa            30
-          header_lote << mensagem_1.to_s.format_size(40) # 1a mensagem             40
-          header_lote << mensagem_2.to_s.format_size(40) # 2a mensagem             40
-          header_lote << sequencial_remessa.to_s.rjust(8, '0') # numero remessa          8
-          header_lote << data_geracao # data gravacao           8
-          header_lote << ''.rjust(8, '0') # data do credito         8
-          header_lote << ''.rjust(33, ' ') # complemento             33
+          header_lote << documento_cedente.to_s.rjust(15, '0')                        # inscricao cedente       15
+          header_lote << convenio_lote                                                # codigo do convenio      20
+          header_lote << info_conta                                                   # informacoes conta       20
+          header_lote << empresa_mae.format_size(30)                                  # nome empresa            30
+          header_lote << mensagem_1.to_s.format_size(40)                              # 1a mensagem             40
+          header_lote << mensagem_2.to_s.format_size(40)                              # 2a mensagem             40
+          header_lote << sequencial_remessa.to_s.rjust(8, '0')                        # numero remessa          8
+          header_lote << data_geracao                                                 # data gravacao           8
+          header_lote << ''.rjust(8, '0')                                             # data do credito         8
+          header_lote << ''.rjust(33, ' ')                                            # complemento             33
           header_lote
         end
 
@@ -137,45 +137,45 @@ module Brcobranca
         def monta_segmento_p(pagamento, nro_lote, sequencial)
           # campos com * na frente nao foram implementados
           #                                                             # DESCRICAO                             TAMANHO
-          segmento_p = cod_banco # codigo banco                          3
-          segmento_p << nro_lote.to_s.rjust(4, '0') # lote de servico                       4
-          segmento_p << '3' # tipo de registro                      1
-          segmento_p << sequencial.to_s.rjust(5, '0') # num. sequencial do registro no lote   5
-          segmento_p << 'P' # cod. segmento                         1
-          segmento_p << ' ' # uso exclusivo                         1
-          segmento_p << '01' # cod. movimento remessa                2
-          segmento_p << agencia.to_s.rjust(5, '0') # agencia                               5
-          segmento_p << digito_agencia.to_s # dv agencia                            1
-          segmento_p << complemento_p(pagamento) # informacoes da conta                  34
-          segmento_p << codigo_carteira # codigo da carteira                    1
-          segmento_p << forma_cadastramento # forma de cadastro do titulo           1
-          segmento_p << tipo_documento # tipo de documento                     1
-          segmento_p << emissao_boleto # identificaco emissao                  1
-          segmento_p << distribuicao_boleto # indentificacao entrega                1
-          segmento_p << pagamento.numero_documento.to_s.rjust(15, '0') # uso exclusivo                         4
-          segmento_p << pagamento.data_vencimento.strftime('%d%m%Y') # data de venc.                         8
-          segmento_p << pagamento.formata_valor(15) # valor documento                       15
-          segmento_p << ''.rjust(5, '0') # agencia cobradora                     5
-          segmento_p << '0' # dv agencia cobradora                  1
-          segmento_p << especie_titulo # especie do titulo                     2
-          segmento_p << aceite # aceite                                1
-          segmento_p << pagamento.data_emissao.strftime('%d%m%Y') # data de emissao titulo                8
-          segmento_p << '0' # cod. do juros                         1   *
-          segmento_p << ''.rjust(8, '0') # data juros                            8   *
-          segmento_p << ''.rjust(15, '0') # valor juros                           15  *
-          segmento_p << pagamento.cod_desconto # cod. do desconto                      1
-          segmento_p << pagamento.formata_data_desconto('%d%m%Y') # data desconto                         8
-          segmento_p << pagamento.formata_valor_desconto(15) # valor desconto                        15
-          segmento_p << pagamento.formata_valor_iof(15) # valor IOF                             15
-          segmento_p << pagamento.formata_valor_abatimento(15) # valor abatimento                      15
-          segmento_p << ''.rjust(25, ' ') # identificacao titulo empresa          25  *
-          segmento_p << '0' # cod. para protesto                    1   *
-          segmento_p << '00' # dias para protesto                    2   *
-          segmento_p << '0' # cod. para baixa                       1   *
-          segmento_p << '000' # dias para baixa                       2   *
-          segmento_p << '09' # cod. da moeda                         2
-          segmento_p << ''.rjust(10, '0') # uso exclusivo                         10
-          segmento_p << ' ' # uso exclusivo                         1
+          segmento_p = cod_banco                                        # codigo banco                          3
+          segmento_p << nro_lote.to_s.rjust(4, '0')                     # lote de servico                       4
+          segmento_p << '3'                                             # tipo de registro                      1
+          segmento_p << sequencial.to_s.rjust(5, '0')                   # num. sequencial do registro no lote   5
+          segmento_p << 'P'                                             # cod. segmento                         1
+          segmento_p << ' '                                             # uso exclusivo                         1
+          segmento_p << '01'                                            # cod. movimento remessa                2
+          segmento_p << agencia.to_s.rjust(5, '0')                      # agencia                               5
+          segmento_p << digito_agencia.to_s                             # dv agencia                            1
+          segmento_p << complemento_p(pagamento)                        # informacoes da conta                  34
+          segmento_p << codigo_carteira                                 # codigo da carteira                    1
+          segmento_p << forma_cadastramento                             # forma de cadastro do titulo           1
+          segmento_p << tipo_documento                                  # tipo de documento                     1
+          segmento_p << emissao_boleto                                  # identificaco emissao                  1
+          segmento_p << distribuicao_boleto                             # indentificacao entrega                1
+          segmento_p << pagamento.numero_documento.to_s.rjust(15, '0')  # uso exclusivo                         4
+          segmento_p << pagamento.data_vencimento.strftime('%d%m%Y')    # data de venc.                         8
+          segmento_p << pagamento.formata_valor(15)                     # valor documento                       15
+          segmento_p << ''.rjust(5, '0')                                # agencia cobradora                     5
+          segmento_p << '0'                                             # dv agencia cobradora                  1
+          segmento_p << especie_titulo                                  # especie do titulo                     2
+          segmento_p << aceite                                          # aceite                                1
+          segmento_p << pagamento.data_emissao.strftime('%d%m%Y')       # data de emissao titulo                8
+          segmento_p << pagamento.codigo_multa                          # cod. do juros                         1   *
+          segmento_p << pagamento.formata_data_multa('%d%m%Y')          # data juros                            8   *
+          segmento_p << pagamento.formata_valor_multa(15)               # valor juros                           15  *
+          segmento_p << pagamento.cod_desconto                          # cod. do desconto                      1
+          segmento_p << pagamento.formata_data_desconto('%d%m%Y')       # data desconto                         8
+          segmento_p << pagamento.formata_valor_desconto(15)            # valor desconto                        15
+          segmento_p << pagamento.formata_valor_iof(15)                 # valor IOF                             15
+          segmento_p << pagamento.formata_valor_abatimento(15)          # valor abatimento                      15
+          segmento_p << ''.rjust(25, ' ')                               # identificacao titulo empresa          25  *
+          segmento_p << pagamento.cod_protesto                          # cod. para protesto                    1   *
+          segmento_p << pagamento.dias_protesto.to_s.rjust(2, '0')      # dias para protesto                    2   *
+          segmento_p << '0'                                             # cod. para baixa                       1   *
+          segmento_p << '000'                                           # dias para baixa                       2   *
+          segmento_p << '09'                                            # cod. da moeda                         2
+          segmento_p << ''.rjust(10, '0')                               # uso exclusivo                         10
+          segmento_p << ' '                                             # uso exclusivo                         1
           segmento_p
         end
 
@@ -191,29 +191,29 @@ module Brcobranca
         # @return [String]
         #
         def monta_segmento_q(pagamento, nro_lote, sequencial)
-          segmento_q = '' # CAMPO                                TAMANHO
-          segmento_q << cod_banco # codigo banco                         3
-          segmento_q << nro_lote.to_s.rjust(4, '0') # lote de servico                      4
-          segmento_q << '3' # tipo de registro                     1
-          segmento_q << sequencial.to_s.rjust(5, '0') # num. sequencial do registro no lote  5
-          segmento_q << 'Q' # cod. segmento                        1
-          segmento_q << ' ' # uso exclusivo                        1
-          segmento_q << '01' # cod. movimento remessa               2
-          segmento_q << pagamento.identificacao_sacado(false) # tipo insc. sacado                    1
-          segmento_q << pagamento.documento_sacado.to_s.rjust(15, '0') # documento sacado                     14
-          segmento_q << pagamento.nome_sacado.format_size(40) # nome cliente                         40
-          segmento_q << pagamento.endereco_sacado.format_size(40) # endereco cliente                     40
-          segmento_q << pagamento.bairro_sacado.format_size(15) # bairro                               15
-          segmento_q << pagamento.cep_sacado[0..4] # cep                                  5
-          segmento_q << pagamento.cep_sacado[5..7] # sufixo cep                           3
-          segmento_q << pagamento.cidade_sacado.format_size(15) # cidade                               15
-          segmento_q << pagamento.uf_sacado # uf                                   2
-          segmento_q << pagamento.identificacao_avalista(false) # identificacao do sacador             1
-          segmento_q << pagamento.documento_avalista.to_s.rjust(15, '0') # documento sacador                    15
-          segmento_q << pagamento.nome_avalista.format_size(40) # nome avalista                         40
-          segmento_q << ''.rjust(3, '0') # cod. banco correspondente            3
-          segmento_q << ''.rjust(20, ' ') # nosso numero banco correspondente    20
-          segmento_q << ''.rjust(8, ' ') # uso exclusivo                        8
+          segmento_q = ''                                                 # CAMPO                                TAMANHO
+          segmento_q << cod_banco                                         # codigo banco                         3
+          segmento_q << nro_lote.to_s.rjust(4, '0')                       # lote de servico                      4
+          segmento_q << '3'                                               # tipo de registro                     1
+          segmento_q << sequencial.to_s.rjust(5, '0')                     # num. sequencial do registro no lote  5
+          segmento_q << 'Q'                                               # cod. segmento                        1
+          segmento_q << ' '                                               # uso exclusivo                        1
+          segmento_q << '01'                                              # cod. movimento remessa               2
+          segmento_q << pagamento.identificacao_sacado(false)             # tipo insc. sacado                    1
+          segmento_q << pagamento.documento_sacado.to_s.rjust(15, '0')    # documento sacado                     14
+          segmento_q << pagamento.nome_sacado.format_size(40)             # nome cliente                         40
+          segmento_q << pagamento.endereco_sacado.format_size(40)         # endereco cliente                     40
+          segmento_q << pagamento.bairro_sacado.format_size(15)           # bairro                               15
+          segmento_q << pagamento.cep_sacado[0..4]                        # cep                                  5
+          segmento_q << pagamento.cep_sacado[5..7]                        # sufixo cep                           3
+          segmento_q << pagamento.cidade_sacado.format_size(15)           # cidade                               15
+          segmento_q << pagamento.uf_sacado                               # uf                                   2
+          segmento_q << pagamento.identificacao_avalista(false)           # identificacao do sacador             1
+          segmento_q << pagamento.documento_avalista.to_s.rjust(15, '0')  # documento sacador                    15
+          segmento_q << pagamento.nome_avalista.format_size(40)           # nome avalista                         40
+          segmento_q << ''.rjust(3, '0')                                  # cod. banco correspondente            3
+          segmento_q << ''.rjust(20, ' ')                                 # nosso numero banco correspondente    20
+          segmento_q << ''.rjust(8, ' ')                                  # uso exclusivo                        8
           segmento_q
         end
 
@@ -228,13 +228,13 @@ module Brcobranca
         # @return [String]
         #
         def monta_trailer_lote(nro_lote, nro_registros)
-          trailer_lote = '' # CAMPO                   # TAMANHO
-          trailer_lote << cod_banco # codigo banco            3
-          trailer_lote << nro_lote.to_s.rjust(4, '0') # lote de servico         4
-          trailer_lote << '5' # tipo de servico         1
-          trailer_lote << ''.rjust(9, ' ') # uso exclusivo           9
-          trailer_lote << nro_registros.to_s.rjust(6, '0') # qtde de registros lote  6
-          trailer_lote << complemento_trailer # uso exclusivo           217
+          trailer_lote = ''                                               # CAMPO                   # TAMANHO
+          trailer_lote << cod_banco                                       # codigo banco            3
+          trailer_lote << nro_lote.to_s.rjust(4, '0')                     # lote de servico         4
+          trailer_lote << '5'                                             # tipo de servico         1
+          trailer_lote << ''.rjust(9, ' ')                                # uso exclusivo           9
+          trailer_lote << nro_registros.to_s.rjust(6, '0')                # qtde de registros lote  6
+          trailer_lote << complemento_trailer                             # uso exclusivo           217
           trailer_lote
         end
 

--- a/lib/brcobranca/remessa/cnab400/banco_brasil.rb
+++ b/lib/brcobranca/remessa/cnab400/banco_brasil.rb
@@ -149,6 +149,20 @@ module Brcobranca
           detalhe << ' '                                                      # complemento (brancos)             X[01] 394 a 394
           detalhe << sequencial.to_s.rjust(6, '0')                            # sequencial do registro            9[06] 395 a 400
         end
+
+        def monta_detalhe_multa(pagamento, sequencial)
+          raise Brcobranca::RemessaInvalida, pagamento if pagamento.invalid?
+          return false if %w[0 9].include?(pagamento.codigo_multa)
+
+          detalhe = '5'
+          detalhe << '99'                                                # Tipo de Serviço: “99” (Cobrança de Multa)   9[02]       002 a 003
+          detalhe << '2'                                                 # código da multa                             9[01]       004 a 004
+          detalhe << pagamento.formata_data_multa                        # Data de Inicio da Cobrança da Multa         9[06]       005 a 010
+          detalhe << pagamento.formata_valor_multa(12)                   # percentual multa                            9[04]       011 a 022
+          detalhe << ''.rjust(372, ' ')                                  # brancos                                     9[372]      023 a 394
+          detalhe << sequencial.to_s.rjust(6, '0')                       # numero do registro do arquivo               9[06]       395 a 400
+          detalhe
+        end
       end
     end
   end

--- a/lib/brcobranca/remessa/cnab400/banco_brasil.rb
+++ b/lib/brcobranca/remessa/cnab400/banco_brasil.rb
@@ -158,7 +158,7 @@ module Brcobranca
           detalhe << '99'                                                # Tipo de Serviço: “99” (Cobrança de Multa)   9[02]       002 a 003
           detalhe << '2'                                                 # código da multa                             9[01]       004 a 004
           detalhe << pagamento.formata_data_multa                        # Data de Inicio da Cobrança da Multa         9[06]       005 a 010
-          detalhe << pagamento.formata_valor_multa(12)                   # percentual multa                            9[04]       011 a 022
+          detalhe << pagamento.formata_valor_multa(12)                   # percentual multa                            9[12]       011 a 022
           detalhe << ''.rjust(372, ' ')                                  # brancos                                     9[372]      023 a 394
           detalhe << sequencial.to_s.rjust(6, '0')                       # numero do registro do arquivo               9[06]       395 a 400
           detalhe

--- a/lib/brcobranca/remessa/cnab400/base.rb
+++ b/lib/brcobranca/remessa/cnab400/base.rb
@@ -73,6 +73,11 @@ module Brcobranca
           pagamentos.each do |pagamento|
             contador += 1
             ret << monta_detalhe(pagamento, contador)
+            next unless respond_to?(:monta_detalhe_multa)
+
+            contador += 1
+            linha = monta_detalhe_multa(pagamento, contador)
+            linha ? ret << linha : contador -= 1
           end
           ret << monta_trailer(contador + 1)
 

--- a/lib/brcobranca/remessa/cnab400/bradesco.rb
+++ b/lib/brcobranca/remessa/cnab400/bradesco.rb
@@ -7,13 +7,11 @@ module Brcobranca
         # codigo da empresa (informado pelo Bradesco no cadastramento)
         attr_accessor :codigo_empresa
 
-        validates_presence_of :agencia, :conta_corrente, message: 'não pode estar em branco.'
-        validates_presence_of :codigo_empresa, :sequencial_remessa,
-                              :digito_conta, message: 'não pode estar em branco.'
+        validates_presence_of :agencia, :conta_corrente, :codigo_empresa,
+                              :sequencial_remessa, :digito_conta, message: 'não pode estar em branco.'
         validates_length_of :codigo_empresa, maximum: 20, message: 'deve ser menor ou igual a 20 dígitos.'
         validates_length_of :agencia, maximum: 5, message: 'deve ter 5 dígitos.'
-        validates_length_of :conta_corrente, maximum: 7, message: 'deve ter 7 dígitos.'
-        validates_length_of :sequencial_remessa, maximum: 7, message: 'deve ter 7 dígitos.'
+        validates_length_of :conta_corrente, :sequencial_remessa, maximum: 7, message: 'deve ter 7 dígitos.'
         validates_length_of :carteira, maximum: 2, message: 'deve ter no máximo 2 dígitos.'
         validates_length_of :digito_conta, maximum: 1, message: 'deve ter 1 dígito.'
 
@@ -68,7 +66,6 @@ module Brcobranca
         # Formata o endereco do sacado
         # de acordo com os caracteres disponiveis (40)
         # concatenando o endereco, cidade e uf
-        #
         def formata_endereco_sacado(pgto)
           endereco = "#{pgto.endereco_sacado}, #{pgto.cidade_sacado}/#{pgto.uf_sacado}"
           return endereco.ljust(40, ' ') if endereco.size <= 40
@@ -78,51 +75,51 @@ module Brcobranca
         def monta_detalhe(pagamento, sequencial)
           raise Brcobranca::RemessaInvalida, pagamento if pagamento.invalid?
 
-          detalhe = '1'                                               # identificacao do registro                   9[01]       001 a 001
-          detalhe << ''.rjust(5, '0')                                 # agencia de debito (op)                      9[05]       002 a 006
-          detalhe << ''.rjust(1, '0')                                 # digito da agencia de debito (op)            X[01]       007 a 007
-          detalhe << ''.rjust(5, '0')                                 # razao da conta corrente de debito (op)      9[05]       008 a 012
-          detalhe << ''.rjust(7, '0')                                 # conta corrente (op)                         9[07]       013 a 019
-          detalhe << ''.rjust(1, '0')                                 # digito da conta corrente (op)               X[01]       020 a 020
-          detalhe << identificacao_empresa                            # identficacao da empresa                     X[17]       021 a 037
-          detalhe << ''.rjust(25, ' ')                                # num. controle                               X[25]       038 a 062
-          detalhe << ''.rjust(3, '0')                                 # codigo do banco (debito automatico apenas)  9[03]       063 a 065
-          detalhe << ''.rjust(1, '0')                                 # campo da multa                              9[01]       066 a 066 *
-          detalhe << ''.rjust(4, '0')                                 # percentual multa                            9[04]       067 a 070 *
-          detalhe << pagamento.nosso_numero.to_s.rjust(11, '0')       # identificacao do titulo (nosso numero)      9[11]       071 a 081
-          detalhe << digito_nosso_numero(pagamento.nosso_numero).to_s # digito de conferencia do nosso numero (dv)  X[01]       082 a 082
-          detalhe << ''.rjust(10, '0')                                # desconto por dia                            9[10]       083 a 092
-          detalhe << '2'                                              # condicao emissao boleto (2 = cliente)       9[01]       093 a 093
-          detalhe << 'N'                                              # emite boleto para debito                    X[01]       094 a 094
-          detalhe << ''.rjust(10, ' ')                                # operacao no banco (brancos)                 X[10]       095 a 104
-          detalhe << ' '                                              # indicador rateio                            X[01]       105 a 105
-          detalhe << '2'                                              # endereco para aviso debito (op 2 = ignora)  9[01]       106 a 106
-          detalhe << ''.rjust(2, ' ')                                 # brancos                                     X[02]       107 a 108
-          detalhe << pagamento.identificacao_ocorrencia               # identificacao ocorrencia              9[02]
-          detalhe << pagamento.numero_documento.to_s.rjust(10, ' ')   # numero do documento alfanum.                X[10]       111 a 120
-          detalhe << pagamento.data_vencimento.strftime('%d%m%y')     # data de vencimento                          9[06]       121 a 126
-          detalhe << pagamento.formata_valor                          # valor do titulo                             9[13]       127 a 139
-          detalhe << ''.rjust(3, '0')                                 # banco encarregado (zeros)                   9[03]       140 a 142
-          detalhe << ''.rjust(5, '0')                                 # agencia depositaria (zeros)                 9[05]       143 a 147
-          detalhe << '99'                                             # especie do titulo                           9[02]       148 a 149
-          detalhe << 'N'                                              # identificacao (sempre N)                    X[01]       150 a 150
-          detalhe << pagamento.data_emissao.strftime('%d%m%y')        # data de emissao                             9[06]       151 a 156
-          detalhe << ''.rjust(2, '0')                                 # 1a instrucao                                9[02]       157 a 158
-          detalhe << ''.rjust(2, '0')                                 # 2a instrucao                                9[02]       159 a 160
-          detalhe << pagamento.formata_valor_mora                     # mora                                        9[13]       161 a 173
-          detalhe << pagamento.formata_data_desconto                  # data desconto                               9[06]       174 a 179
-          detalhe << pagamento.formata_valor_desconto                 # valor desconto                              9[13]       180 a 192
-          detalhe << pagamento.formata_valor_iof                      # valor iof                                   9[13]       193 a 205
-          detalhe << pagamento.formata_valor_abatimento               # valor abatimento                            9[13]       206 a 218
-          detalhe << pagamento.identificacao_sacado                   # identificacao do pagador                    9[02]       219 a 220
-          detalhe << pagamento.documento_sacado.to_s.rjust(14, '0')   # cpf/cnpj do pagador                         9[14]       221 a 234
-          detalhe << pagamento.nome_sacado.format_size(40)            # nome do pagador                             9[40]       235 a 274
-          detalhe << formata_endereco_sacado(pagamento)               # endereco do pagador                         X[40]       275 a 314
-          detalhe << ''.rjust(12, ' ')                                # 1a mensagem                                 X[12]       315 a 326
-          detalhe << pagamento.cep_sacado[0..4]                       # cep do pagador                              9[05]       327 a 331
-          detalhe << pagamento.cep_sacado[5..7]                       # sufixo do cep do pagador                    9[03]       332 a 334
-          detalhe << ''.rjust(60, ' ')                                # sacador/2a mensagem - verificar             X[60]       335 a 394
-          detalhe << sequencial.to_s.rjust(6, '0')                    # numero do registro do arquivo               9[06]       395 a 400
+          detalhe = '1'                                                  # identificacao do registro                   9[01]       001 a 001
+          detalhe << ''.rjust(5, '0')                                    # agencia de debito (op)                      9[05]       002 a 006
+          detalhe << ''.rjust(1, '0')                                    # digito da agencia de debito (op)            X[01]       007 a 007
+          detalhe << ''.rjust(5, '0')                                    # razao da conta corrente de debito (op)      9[05]       008 a 012
+          detalhe << ''.rjust(7, '0')                                    # conta corrente (op)                         9[07]       013 a 019
+          detalhe << ''.rjust(1, '0')                                    # digito da conta corrente (op)               X[01]       020 a 020
+          detalhe << identificacao_empresa                               # identficacao da empresa                     X[17]       021 a 037
+          detalhe << ''.rjust(25, ' ')                                   # num. controle                               X[25]       038 a 062
+          detalhe << ''.rjust(3, '0')                                    # codigo do banco (debito automatico apenas)  9[03]       063 a 065
+          detalhe << pagamento.codigo_multa                              # campo da multa                              9[01]       066 a 066 *
+          detalhe << pagamento.formata_valor_multa(4)                    # percentual multa                            9[04]       067 a 070 *
+          detalhe << pagamento.nosso_numero.to_s.rjust(11, '0')          # identificacao do titulo (nosso numero)      9[11]       071 a 081
+          detalhe << digito_nosso_numero(pagamento.nosso_numero).to_s    # digito de conferencia do nosso numero (dv)  X[01]       082 a 082
+          detalhe << ''.rjust(10, '0')                                   # desconto por dia                            9[10]       083 a 092
+          detalhe << '2'                                                 # condicao emissao boleto (2 = cliente)       9[01]       093 a 093
+          detalhe << 'N'                                                 # emite boleto para debito                    X[01]       094 a 094
+          detalhe << ''.rjust(10, ' ')                                   # operacao no banco (brancos)                 X[10]       095 a 104
+          detalhe << ' '                                                 # indicador rateio                            X[01]       105 a 105
+          detalhe << '2'                                                 # endereco para aviso debito (op 2 = ignora)  9[01]       106 a 106
+          detalhe << ''.rjust(2, ' ')                                    # brancos                                     X[02]       107 a 108
+          detalhe << pagamento.identificacao_ocorrencia                  # identificacao ocorrencia              9[02]
+          detalhe << pagamento.numero_documento.to_s.rjust(10, ' ')      # numero do documento alfanum.                X[10]       111 a 120
+          detalhe << pagamento.data_vencimento.strftime('%d%m%y')        # data de vencimento                          9[06]       121 a 126
+          detalhe << pagamento.formata_valor                             # valor do titulo                             9[13]       127 a 139
+          detalhe << ''.rjust(3, '0')                                    # banco encarregado (zeros)                   9[03]       140 a 142
+          detalhe << ''.rjust(5, '0')                                    # agencia depositaria (zeros)                 9[05]       143 a 147
+          detalhe << '99'                                                # especie do titulo                           9[02]       148 a 149
+          detalhe << 'N'                                                 # identificacao (sempre N)                    X[01]       150 a 150
+          detalhe << pagamento.data_emissao.strftime('%d%m%y')           # data de emissao                             9[06]       151 a 156
+          detalhe << pagamento.cod_primeira_instrucao.to_s.rjust(2, '0') # 1a instrucao                                9[02]       157 a 158
+          detalhe << pagamento.cod_segunda_instrucao.to_s.rjust(2, '0')  # 2a instrucao                                9[02]       159 a 160
+          detalhe << pagamento.formata_valor_mora                        # mora                                        9[13]       161 a 173
+          detalhe << pagamento.formata_data_desconto                     # data desconto                               9[06]       174 a 179
+          detalhe << pagamento.formata_valor_desconto                    # valor desconto                              9[13]       180 a 192
+          detalhe << pagamento.formata_valor_iof                         # valor iof                                   9[13]       193 a 205
+          detalhe << pagamento.formata_valor_abatimento                  # valor abatimento                            9[13]       206 a 218
+          detalhe << pagamento.identificacao_sacado                      # identificacao do pagador                    9[02]       219 a 220
+          detalhe << pagamento.documento_sacado.to_s.rjust(14, '0')      # cpf/cnpj do pagador                         9[14]       221 a 234
+          detalhe << pagamento.nome_sacado.format_size(40)               # nome do pagador                             9[40]       235 a 274
+          detalhe << formata_endereco_sacado(pagamento)                  # endereco do pagador                         X[40]       275 a 314
+          detalhe << ''.rjust(12, ' ')                                   # 1a mensagem                                 X[12]       315 a 326
+          detalhe << pagamento.cep_sacado[0..4]                          # cep do pagador                              9[05]       327 a 331
+          detalhe << pagamento.cep_sacado[5..7]                          # sufixo do cep do pagador                    9[03]       332 a 334
+          detalhe << ''.rjust(60, ' ')                                   # sacador/2a mensagem - verificar             X[60]       335 a 394
+          detalhe << sequencial.to_s.rjust(6, '0')                       # numero do registro do arquivo               9[06]       395 a 400
           detalhe
         end
       end

--- a/lib/brcobranca/remessa/cnab400/itau.rb
+++ b/lib/brcobranca/remessa/cnab400/itau.rb
@@ -110,8 +110,8 @@ module Brcobranca
           detalhe << '99'                                                   # especie  do titulo                    X[02]
           detalhe << aceite                                                 # aceite (A/N)                          X[01]
           detalhe << pagamento.data_emissao.strftime('%d%m%y')              # data de emissao                       9[06]
-          detalhe << ''.rjust(2, '0')                                       # 1a instrucao - deixar zero            X[02]
-          detalhe << ''.rjust(2, '0')                                       # 2a instrucao - deixar zero            X[02]
+          detalhe << pagamento.cod_primeira_instrucao.to_s.rjust(2, '0')    # 1a instrucao - deixar zero            X[02]
+          detalhe << pagamento.cod_segunda_instrucao.to_s.rjust(2, '0')     # 2a instrucao - deixar zero            X[02]
           detalhe << pagamento.formata_valor_mora                           # valor mora ao dia                     9[13]
           detalhe << pagamento.formata_data_desconto                        # data limite para desconto             9[06]
           detalhe << pagamento.formata_valor_desconto                       # valor do desconto                     9[13]
@@ -128,7 +128,7 @@ module Brcobranca
           detalhe << pagamento.uf_sacado                                    # uf do pagador                         X[02]
           detalhe << pagamento.nome_avalista.format_size(30)                # nome do sacador/avalista              X[30]
           detalhe << ''.rjust(4, ' ')                                       # complemento do registro               X[04]
-          detalhe << ''.rjust(6, '0')                                       # data da mora                          9[06] *
+          detalhe << pagamento.formata_data_multa                           # data da mora                          9[06] *
           detalhe << '03'                                                   # quantidade de dias do prazo           9[02] *
           detalhe << ''.rjust(1, ' ')                                       # complemento do registro (brancos)     X[01]
           detalhe << sequencial.to_s.rjust(6, '0')                          # numero do registro no arquivo         9[06]

--- a/lib/brcobranca/remessa/cnab400/itau.rb
+++ b/lib/brcobranca/remessa/cnab400/itau.rb
@@ -128,10 +128,23 @@ module Brcobranca
           detalhe << pagamento.uf_sacado                                    # uf do pagador                         X[02]
           detalhe << pagamento.nome_avalista.format_size(30)                # nome do sacador/avalista              X[30]
           detalhe << ''.rjust(4, ' ')                                       # complemento do registro               X[04]
-          detalhe << pagamento.formata_data_multa                           # data da mora                          9[06] *
+          detalhe << pagamento.formata_data_mora                            # data da mora                          9[06] *
           detalhe << '03'                                                   # quantidade de dias do prazo           9[02] *
           detalhe << ''.rjust(1, ' ')                                       # complemento do registro (brancos)     X[01]
           detalhe << sequencial.to_s.rjust(6, '0')                          # numero do registro no arquivo         9[06]
+          detalhe
+        end
+
+        def monta_detalhe_multa(pagamento, sequencial)
+          raise Brcobranca::RemessaInvalida, pagamento if pagamento.invalid?
+          return false if pagamento.codigo_multa == '0'
+
+          detalhe = '2'
+          detalhe << '2'                                                 # código da multa                             9[01]       002 a 002
+          detalhe << pagamento.formata_data_multa('%d%m%Y')              # Data de Inicio da Cobrança da Multa         9[08]       003 a 010
+          detalhe << pagamento.formata_valor_multa(12)                   # percentual multa                            9[13]       011 a 023
+          detalhe << ''.rjust(370, ' ')                                  # brancos                                     9[370]      024 a 394
+          detalhe << sequencial.to_s.rjust(6, '0')                       # numero do registro do arquivo               9[06]       395 a 400
           detalhe
         end
       end

--- a/lib/brcobranca/remessa/cnab400/itau.rb
+++ b/lib/brcobranca/remessa/cnab400/itau.rb
@@ -142,8 +142,8 @@ module Brcobranca
           detalhe = '2'
           detalhe << '2'                                                 # código da multa                             9[01]       002 a 002
           detalhe << pagamento.formata_data_multa('%d%m%Y')              # Data de Inicio da Cobrança da Multa         9[08]       003 a 010
-          detalhe << pagamento.formata_valor_multa(12)                   # percentual multa                            9[13]       011 a 023
-          detalhe << ''.rjust(370, ' ')                                  # brancos                                     9[370]      024 a 394
+          detalhe << pagamento.formata_valor_multa(13)                   # percentual multa                            9[13]       011 a 023
+          detalhe << ''.rjust(371, ' ')                                  # brancos                                     9[371]      024 a 395
           detalhe << sequencial.to_s.rjust(6, '0')                       # numero do registro do arquivo               9[06]       395 a 400
           detalhe
         end

--- a/lib/brcobranca/remessa/cnab400/santander.rb
+++ b/lib/brcobranca/remessa/cnab400/santander.rb
@@ -152,7 +152,7 @@ module Brcobranca
           # 06 = PROTESTAR (VIDE POSIÇÃO392/393)
           # 07 = NÃO PROTESTAR
           # 08 = NÃO COBRAR JUROS DE MORA
-          detalhe << '00'                                                   # Instrução para o título               9[02]
+          detalhe << pagamento.cod_primeira_instrucao.to_s.rjust(2, '0')    # Instrução para o título               9[02]
           detalhe << '00'                                                   # Número de dias válidos para instrução 9[02]
           detalhe << pagamento.formata_valor_mora                           # valor mora ao dia                     9[13]
           detalhe << pagamento.formata_data_desconto                        # data limite para desconto             9[06]

--- a/lib/brcobranca/remessa/pagamento.rb
+++ b/lib/brcobranca/remessa/pagamento.rb
@@ -46,6 +46,8 @@ module Brcobranca
       attr_accessor :valor_desconto
       # <b>OPCIONAL</b>: codigo do desconto (para CNAB240)
       attr_accessor :cod_desconto
+      # <b>OPCIONAL</b>: codigo do protesto
+      attr_accessor :cod_protesto
       # <b>OPCIONAL</b>: valor do IOF
       attr_accessor :valor_iof
       # <b>OPCIONAL</b>: valor do abatimento
@@ -82,7 +84,7 @@ module Brcobranca
                             :cep_sacado, :cidade_sacado, :uf_sacado, message: 'não pode estar em branco.'
       validates_length_of :uf_sacado, is: 2, message: 'deve ter 2 dígitos.'
       validates_length_of :cep_sacado, is: 8, message: 'deve ter 8 dígitos.'
-      validates_length_of :cod_desconto, is: 1, message: 'deve ter 1 dígito.'
+      validates_length_of :cod_desconto, :cod_protesto, is: 1, message: 'deve ter 1 dígito.'
       validates_length_of :especie_titulo, is: 2, message: 'deve ter 2 dígitos.', allow_blank: true
       validates_length_of :identificacao_ocorrencia, is: 2, message: 'deve ter 2 dígitos.'
       validates_length_of :uso_da_empresa, maximum: 25, message: 'deve ter no máximo 25 dígitos.', allow_blank: true, default: ''
@@ -101,6 +103,7 @@ module Brcobranca
           valor_abatimento: 0.0,
           nome_avalista: '',
           cod_desconto: '0',
+          cod_protesto: '0',
           especie_titulo: '01',
           identificacao_ocorrencia: '01',
           codigo_multa: '0',

--- a/lib/brcobranca/remessa/pagamento.rb
+++ b/lib/brcobranca/remessa/pagamento.rb
@@ -70,6 +70,8 @@ module Brcobranca
       attr_accessor :percentual_multa
       # <b>OPCIONAL</b>: Data para cobrança de multa
       attr_accessor :data_multa
+      # <b>OPCIONAL</b>: Data para cobrança de juros mora
+      attr_accessor :data_mora
       # <b>OPCIONAL</b>: Número da Parcela
       attr_accessor :parcela
       # <b>OPCIONAL</b>: Dias para o protesto
@@ -153,6 +155,20 @@ module Brcobranca
       #
       def formata_data_multa(formato = '%d%m%y')
         data_multa.strftime(formato)
+      rescue
+        if formato == '%d%m%y'
+          '000000'
+        else
+          '00000000'
+        end
+      end
+
+      # Formata a data de cobrança da mora
+      #
+      # @return [String]
+      #
+      def formata_data_mora(formato = '%d%m%y')
+        data_mora.strftime(formato)
       rescue
         if formato == '%d%m%y'
           '000000'

--- a/lib/brcobranca/retorno/base.rb
+++ b/lib/brcobranca/retorno/base.rb
@@ -11,6 +11,7 @@ module Brcobranca
       attr_accessor :nosso_numero
       attr_accessor :nosso_numero_com_dv
       attr_accessor :cod_de_ocorrencia
+      attr_accessor :motivos_de_ocorrencia
       attr_accessor :data_de_ocorrencia
       attr_accessor :tipo_cobranca
       attr_accessor :tipo_cobranca_anterior

--- a/lib/brcobranca/retorno/cnab240/caixa.rb
+++ b/lib/brcobranca/retorno/cnab240/caixa.rb
@@ -22,8 +22,9 @@ module Brcobranca
             # parse.field :valor_tarifa, 198..212
             # parse.field :agencia_com_dv, 17..22
 
-            parse.field :nosso_numero, 39..55
-            parse.field :agencia_recebedora_com_dv, 99..103
+            parse.field :cod_de_ocorrencia, 15..16
+            parse.field :motivos_de_ocorrencia, 213..222
+            parse.field :nosso_numero, 41..55
 
             # REGISTRO_U_FIELDS
 

--- a/lib/brcobranca/retorno/cnab400/banco_brasil.rb
+++ b/lib/brcobranca/retorno/cnab400/banco_brasil.rb
@@ -1,0 +1,127 @@
+# -*- encoding: utf-8 -*-
+#
+require 'parseline'
+
+module Brcobranca
+  module Retorno
+    module Cnab400
+      # Formato de Retorno CNAB 400
+      # Baseado em: http://download.itau.com.br/bankline/layout_cobranca_400bytes_cnab_itau_mensagem.pdf
+      class BancoBrasil < Brcobranca::Retorno::Cnab400::Base
+        extend ParseLine::FixedWidth # Extendendo parseline
+
+        # Load lines
+        def self.load_lines(file, options = {})
+          default_options = { except: [1] } # por padrao ignora a primeira linha que é header
+          options = default_options.merge!(options)
+          super file, options
+        end
+
+        fixed_width_layout do |parse|
+          # Todos os campos descritos no documento em ordem
+          # :tipo_de_registro, 0..0 # identificacao do registro transacao
+          # :zeros, 1..2 # zeros
+          # :zeros, 3..16 #zeros
+
+          # :agencia, 17..21 #agencia mantenedora da conta com digito
+          parse.field :agencia_com_dv, 17..21
+
+          # :conta, 22..30 #numero da conta corrente da empresa com digito
+          parse.field :cedente_com_dv, 22..30
+
+          # :convenio, 31..37 #convenio da empresa
+          # :uso_da_empresa, 38..62 #identificacao do titulo na empresa
+
+          # :nosso_numero,63..79 # identificacao do titulo no banco
+          parse.field :nosso_numero, 63..79
+
+          # :tipo_cobranca, 80..80 #tipo de cobranca
+          # :tipo_cobranca_anterior, 81..81 #tipo de cobranca
+
+          # :dias, 82..85 #dias para calculo
+
+          # :natureza_recebimento, 86..87 #natureza do recebimento
+          parse.field :motivos_de_ocorrencia, 86..87, ->(motivos) { motivos.scan(/../).reject { |n| n.to_i.zero? } }
+
+          # :prefixo_titulo, 88..90 #prefixo do titulo
+          parse.field :carteira_variacao, 91..93
+
+          # :conta_caucao, 94..94 #conta caução
+          # :taxa_desconto, 95..99 #taxa para desconto
+          # :taxa_iof, 100..104 #taxa para iof
+
+          # :brancos, 105..105 #brancos
+          parse.field :carteira, 106..107
+
+          # :cod_de_ocorrencia, 108..109 # cod de ocorrencia no banco
+          parse.field :cod_de_ocorrencia, 108..109
+
+          # :data_de_ocorrencia, 110..115 # data de ocorrencia no banco (ddmmaa)
+          parse.field :data_de_ocorrencia, 110..115
+
+          # :n_do_documento, 116..125 # n umero do documento de cobranca (dupl, np etc)
+          # :brancos, 126..145 #complemento de registro
+
+          # :vencimento, 146..151 #data de vencimento do titulo (ddmmaa)
+          parse.field :data_vencimento, 146..151
+
+          # :valor_do_titulo, 152..164 #valor nominal do titulo (ultimos 2 digitos, virgula decimal assumida)
+          parse.field :valor_titulo, 152..164
+
+          # :codigo_do_banco, 165..167 # numero do banco na camara de compensacao
+          parse.field :banco_recebedor, 165..167
+
+          # :agencia_cobradora, 168..171 # agencia cobradora, ag de liquidacao ou baixa
+          # :dac_ag_cobradora, 172..172 # dac da agencia cobradora
+          parse.field :agencia_recebedora_com_dv, 168..172
+
+          # :especie, 173..174 # especie do titulo
+          parse.field :especie_documento, 173..174
+
+          # :data_credito, 295..300 #data de credito desta liquidacao
+          parse.field :data_credito, 175..180
+
+          # :tarifa_de_cobranca, 175..187 #valor da despesa de cobranca (ultimos 2 digitos, virgula decimal assumida)
+          parse.field :valor_tarifa, 181..187
+
+          # parse.field :outras_despesas, 188..200
+          # parse.field :juros_desconto, 201..213
+          # parse.field :iof_desconto, 214..226
+
+          # :valor_do_iof, 214..226 #valor do iof a ser recolhido (ultimos 2 digitos, virgula decimal assumida)
+          parse.field :iof, 214..226
+
+          # :valor_abatimento, 227..239 #valor do abatimento concedido (ultimos 2 digitos, virgula decimal assumida)
+          parse.field :valor_abatimento, 227..239
+
+          # :descontos, 240..252 #valor do desconto concedido (ultimos 2 digitos, virgula decimal assumida)
+          parse.field :desconto, 240..252
+
+          # :valor_principal, 253..265 #valor lancado em conta corrente (ultimos 2 digitos, virgula decimal assumida)
+
+          parse.field :valor_recebido, 253..265
+
+          # :juros_mora_multa, 266..278 #valor de mora e multa pagos pelo sacado (ultimos 2 digitos, virgula decimal assumida)
+          parse.field :juros_mora, 266..278
+
+          # :outros_creditos, 279..291 #valor de outros creditos (ultimos 2 digitos, virgula decimal assumida)
+          parse.field :outros_recebimento, 279..291
+
+          # parse.field :abatimento_nao_aproveitado, 292..304
+          # parse.field :valor_lancamento, 305..317
+          # parse.field :indicativo_lancamento, 318..318
+          # parse.field :indicador_valor, 319..319
+          # parse.field :valor_ajuste, 320..331
+          # :brancos, 332..341 #complemento de registro
+          # :zeros, 342..389 #complemento de registro
+          # :indicativo_liquidacao_parcial, 390..390 #Indicativo de Autorização de Liquidação Parcial
+          # :brancos, 391..391 #complemento de registro
+          # :cod_de_liquidacao, 392..393 #meio pelo qual o título foi liquidado
+
+          # :numero_sequencial, 394..399 #numero sequencial no arquivo
+          parse.field :sequencial, 394..399
+        end
+      end
+    end
+  end
+end

--- a/lib/brcobranca/retorno/cnab400/base.rb
+++ b/lib/brcobranca/retorno/cnab400/base.rb
@@ -11,14 +11,11 @@ module Brcobranca
           return nil if file.blank?
 
           case codigo_banco_do_arquivo(file)
-          when '001'
-            Brcobranca::Retorno::Cnab400::BancoBrasil.load_lines(file, options)
-          when '237'
-            Brcobranca::Retorno::Cnab400::Bradesco.load_lines(file, options)
-          when '341'
-            Brcobranca::Retorno::Cnab400::Itau.load_lines(file, options)
-          else
-            Brcobranca::Retorno::RetornoCnab400.load_lines(file, options)
+          when '001' then Brcobranca::Retorno::Cnab400::BancoBrasil.load_lines(file, options)
+          when '033' then Brcobranca::Retorno::Cnab400::Santander.load_lines(file, options)
+          when '237' then Brcobranca::Retorno::Cnab400::Bradesco.load_lines(file, options)
+          when '341' then Brcobranca::Retorno::Cnab400::Itau.load_lines(file, options)
+          else Brcobranca::Retorno::RetornoCnab400.load_lines(file, options)
           end
         end
 

--- a/lib/brcobranca/retorno/cnab400/base.rb
+++ b/lib/brcobranca/retorno/cnab400/base.rb
@@ -10,15 +10,13 @@ module Brcobranca
         def self.load_lines(file, options = {})
           return nil if file.blank?
 
-          codigo_banco = codigo_banco_do_arquivo(file)
-
-          case codigo_banco
+          case codigo_banco_do_arquivo(file)
+          when '001'
+            Brcobranca::Retorno::Cnab400::BancoBrasil.load_lines(file, options)
           when '237'
             Brcobranca::Retorno::Cnab400::Bradesco.load_lines(file, options)
-
           when '341'
             Brcobranca::Retorno::Cnab400::Itau.load_lines(file, options)
-
           else
             Brcobranca::Retorno::RetornoCnab400.load_lines(file, options)
           end

--- a/lib/brcobranca/retorno/cnab400/bradesco.rb
+++ b/lib/brcobranca/retorno/cnab400/bradesco.rb
@@ -99,7 +99,9 @@ module Brcobranca
           # :origem_pagamento, 301..303
           # :brancos, 304..313
           # :cheque_bradesco, 314..317
-          # :motivo_rejeicao, 318..327
+
+          parse.field :motivos_de_ocorrencia, 318..327, ->(motivos) { motivos.scan(/../).reject { |n| n.to_i.zero? } }
+
           # :brancos, 328..367
           # :numero_do_cartorio, 368..369
           # :numero_do_protocolo, 370..379

--- a/lib/brcobranca/retorno/cnab400/itau.rb
+++ b/lib/brcobranca/retorno/cnab400/itau.rb
@@ -51,7 +51,11 @@ module Brcobranca
           parse.field :carteira, 107..107
 
           # :cod_de_ocorrencia, 108..109 # código de ocorrencia
+          parse.field :cod_de_ocorrencia, 108..109
+
           # :data_de_ocorrencia, 110..115 # data de ocorrencia no banco (ddmmaa)
+          parse.field :data_de_ocorrencia, 110..115
+
           # :n_do_documento, 116..125 # n umero do documento de cobranca (dupl, np etc)
           # :nosso_numero, 126..133 # confirmacao do numero do titulo no banco
           # :brancos, 134..145 #complemento de registro

--- a/lib/brcobranca/retorno/cnab400/itau.rb
+++ b/lib/brcobranca/retorno/cnab400/itau.rb
@@ -106,8 +106,8 @@ module Brcobranca
           # :brancos , 305..310 # complemento de registro
           # :zeros, 311..323 #complemento de registro
           # :nome_do_sacado, 324..353, #nome do sacado
-          # :brancos , 354..376 # complemento de registro
-          # :erros_msg, 377..384 #registros rejeitados ou laegacao do sacado ou registro de mensagem informativa
+          # :brancos , 354..376 # complemento de
+          parse.field :motivos_de_ocorrencia, 377..384, ->(motivos) { motivos.scan(/../).reject { |n| n.to_i.zero? } }
           # :brancos, 385..391 #complemento de registro
           # :cod_de_liquidacao, 392..393 #meio pelo qual o título foi liquidado
 

--- a/lib/brcobranca/retorno/cnab400/santander.rb
+++ b/lib/brcobranca/retorno/cnab400/santander.rb
@@ -6,8 +6,8 @@ module Brcobranca
   module Retorno
     module Cnab400
       # Formato de Retorno CNAB 400
-      # Baseado em: http://www.bb.com.br/docs/pub/emp/empl/dwn/Doc2628CBR643Pos7.pdf
-      class BancoBrasil < Brcobranca::Retorno::Cnab400::Base
+      # Baseado em: http://app.criodigital.com/padrao/cobranca/Documentos/Layout%20Santander.pdf
+      class Santander < Brcobranca::Retorno::Cnab400::Base
         extend ParseLine::FixedWidth # Extendendo parseline
 
         # Load lines
@@ -29,29 +29,14 @@ module Brcobranca
           # :conta, 22..30 #numero da conta corrente da empresa com digito
           parse.field :cedente_com_dv, 22..30
 
-          # :convenio, 31..37 #convenio da empresa
-          # :uso_da_empresa, 38..62 #identificacao do titulo na empresa
+          # :numero_controle_empresa, 37..61 #numero de controle do participante
 
-          # :nosso_numero,63..79 # identificacao do titulo no banco
-          parse.field :nosso_numero, 63..79
+          # :nosso_numero,62..69 # identificacao do titulo no banco
+          parse.field :nosso_numero, 62..69
 
-          # :tipo_cobranca, 80..80 #tipo de cobranca
-          # :tipo_cobranca_anterior, 81..81 #tipo de cobranca
+          # :brancos, 70..106 # brancos
 
-          # :dias, 82..85 #dias para calculo
-
-          # :natureza_recebimento, 86..87 #natureza do recebimento
-          parse.field :motivos_de_ocorrencia, 86..87, ->(motivos) { motivos.scan(/../).reject { |n| n.to_i.zero? } }
-
-          # :prefixo_titulo, 88..90 #prefixo do titulo
-          parse.field :carteira_variacao, 91..93
-
-          # :conta_caucao, 94..94 #conta caução
-          # :taxa_desconto, 95..99 #taxa para desconto
-          # :taxa_iof, 100..104 #taxa para iof
-
-          # :brancos, 105..105 #brancos
-          parse.field :carteira, 106..107
+          parse.field :carteira, 107..107
 
           # :cod_de_ocorrencia, 108..109 # cod de ocorrencia no banco
           parse.field :cod_de_ocorrencia, 108..109
@@ -59,8 +44,13 @@ module Brcobranca
           # :data_de_ocorrencia, 110..115 # data de ocorrencia no banco (ddmmaa)
           parse.field :data_de_ocorrencia, 110..115
 
-          # :n_do_documento, 116..125 # n umero do documento de cobranca (dupl, np etc)
-          # :brancos, 126..145 #complemento de registro
+          # :n_do_documento, 116..125 # numero do documento de cobranca (dupl, np etc)
+          # :nosso_numero, 126..133 # nosso numero de novo?
+          # :codigo_original_remessa, 134..135 # codigo original da remessa
+
+          parse.field :motivos_de_ocorrencia, 136..144, ->(motivos) { motivos.scan(/.../).reject { |n| n.to_i.zero? } }
+
+          # :brancos, 145..145 #complemento de registro
 
           # :vencimento, 146..151 #data de vencimento do titulo (ddmmaa)
           parse.field :data_vencimento, 146..151
@@ -78,15 +68,11 @@ module Brcobranca
           # :especie, 173..174 # especie do titulo
           parse.field :especie_documento, 173..174
 
-          # :data_credito, 295..300 #data de credito desta liquidacao
-          parse.field :data_credito, 175..180
-
           # :tarifa_de_cobranca, 175..187 #valor da despesa de cobranca (ultimos 2 digitos, virgula decimal assumida)
-          parse.field :valor_tarifa, 181..187
+          parse.field :valor_tarifa, 175..187
 
           # parse.field :outras_despesas, 188..200
-          # parse.field :juros_desconto, 201..213
-          # parse.field :iof_desconto, 214..226
+          # :juros_operacao_em_atraso, 201..213 # zeros?
 
           # :valor_do_iof, 214..226 #valor do iof a ser recolhido (ultimos 2 digitos, virgula decimal assumida)
           parse.field :iof, 214..226
@@ -98,7 +84,6 @@ module Brcobranca
           parse.field :desconto, 240..252
 
           # :valor_principal, 253..265 #valor lancado em conta corrente (ultimos 2 digitos, virgula decimal assumida)
-
           parse.field :valor_recebido, 253..265
 
           # :juros_mora_multa, 266..278 #valor de mora e multa pagos pelo sacado (ultimos 2 digitos, virgula decimal assumida)
@@ -107,16 +92,25 @@ module Brcobranca
           # :outros_creditos, 279..291 #valor de outros creditos (ultimos 2 digitos, virgula decimal assumida)
           parse.field :outros_recebimento, 279..291
 
-          # parse.field :abatimento_nao_aproveitado, 292..304
-          # parse.field :valor_lancamento, 305..317
-          # parse.field :indicativo_lancamento, 318..318
-          # parse.field :indicador_valor, 319..319
-          # parse.field :valor_ajuste, 320..331
-          # :brancos, 332..341 #complemento de registro
-          # :zeros, 342..389 #complemento de registro
-          # :indicativo_liquidacao_parcial, 390..390 #Indicativo de Autorização de Liquidação Parcial
-          # :brancos, 391..391 #complemento de registro
-          # :cod_de_liquidacao, 392..393 #meio pelo qual o título foi liquidado
+          # :brancos, 292..292 #complemento de registro
+          # :codigo_aceite, 293..293 #codigo de aceite
+          # :brancos, 294..294 #complemento de registro
+
+          # :data_credito, 295..300 #data de credito desta liquidacao
+          parse.field :data_credito, 295..300
+
+          # :nome_do_sacado, 302..337 #Nome do sacado
+          # :identificador_complemento, 338..338 #Identificador do Complemento
+          # :unidade_moeda, 339..340 #Unidade de valor moeda corrente
+          # :valor_titulo_unidade, 341..353 #Valor do título em outra unidade de valor
+          # :valor_ioc_unidade, 354..366 #Valor do IOC em outra unidade de valor
+          # :valor_debito_credito, 367..379 #Valor do débito ou crédito
+          # :tipo_credito/débito (d/c), 380..380 #tipo crédito/débito (d/c)
+          # :brancos, 381..383 #Brancos
+          # :complemento, 384..385 #Complemento
+          # :sigla_empresa, 386..389 #Sigla da empresa no sistema
+          # :brancos, 390..391 #Brancos
+          # :numero_versão, 392..394 #Número da versão
 
           # :numero_sequencial, 394..399 #numero sequencial no arquivo
           parse.field :sequencial, 394..399

--- a/lib/brcobranca/retorno/cnab400/santander.rb
+++ b/lib/brcobranca/retorno/cnab400/santander.rb
@@ -49,9 +49,7 @@ module Brcobranca
           # :nosso_numero, 126..133 # nosso numero de novo?
           # :codigo_original_remessa, 134..135 # codigo original da remessa
 
-          parse.field :motivos_de_ocorrencia, 136..144, lambda do |motivos|
-            motivos.scan(/.../).reject { |n| n.to_i.zero? }
-          end
+          parse.field :motivos_de_ocorrencia, 134..144, ->(motivos) { motivos.scan(/.../).reject { |n| n.to_i.zero? } }
 
           # :brancos, 145..145 #complemento de registro
 

--- a/lib/brcobranca/retorno/cnab400/santander.rb
+++ b/lib/brcobranca/retorno/cnab400/santander.rb
@@ -1,5 +1,6 @@
+# frozen_string_literal: true
 # -*- encoding: utf-8 -*-
-#
+
 require 'parseline'
 
 module Brcobranca

--- a/lib/brcobranca/retorno/cnab400/santander.rb
+++ b/lib/brcobranca/retorno/cnab400/santander.rb
@@ -29,7 +29,7 @@ module Brcobranca
           # :conta, 22..30 #numero da conta corrente da empresa com digito
           parse.field :cedente_com_dv, 22..30
 
-          # :numero_controle_empresa, 37..61 #numero de controle do participante
+          # :numero_controle_empresa, 37..61 #numero de controle participante
 
           # :nosso_numero,62..69 # identificacao do titulo no banco
           parse.field :nosso_numero, 62..69
@@ -41,55 +41,57 @@ module Brcobranca
           # :cod_de_ocorrencia, 108..109 # cod de ocorrencia no banco
           parse.field :cod_de_ocorrencia, 108..109
 
-          # :data_de_ocorrencia, 110..115 # data de ocorrencia no banco (ddmmaa)
+          # :data_de_ocorrencia, 110..115 # data ocorrencia no banco (ddmmaa)
           parse.field :data_de_ocorrencia, 110..115
 
-          # :n_do_documento, 116..125 # numero do documento de cobranca (dupl, np etc)
+          # :n_do_documento, 116..125 # numero do documento de cobranca
           # :nosso_numero, 126..133 # nosso numero de novo?
           # :codigo_original_remessa, 134..135 # codigo original da remessa
 
-          parse.field :motivos_de_ocorrencia, 136..144, ->(motivos) { motivos.scan(/.../).reject { |n| n.to_i.zero? } }
+          parse.field :motivos_de_ocorrencia, 136..144, lambda do |motivos|
+            motivos.scan(/.../).reject { |n| n.to_i.zero? }
+          end
 
           # :brancos, 145..145 #complemento de registro
 
           # :vencimento, 146..151 #data de vencimento do titulo (ddmmaa)
           parse.field :data_vencimento, 146..151
 
-          # :valor_do_titulo, 152..164 #valor nominal do titulo (ultimos 2 digitos, virgula decimal assumida)
+          # :valor_do_titulo, 152..164 #valor nominal do titulo
           parse.field :valor_titulo, 152..164
 
-          # :codigo_do_banco, 165..167 # numero do banco na camara de compensacao
+          # :codigo_do_banco, 165..167 # numero do banco na compensacao
           parse.field :banco_recebedor, 165..167
 
-          # :agencia_cobradora, 168..171 # agencia cobradora, ag de liquidacao ou baixa
+          # :agencia_cobradora, 168..171 # agencia cobradora
           # :dac_ag_cobradora, 172..172 # dac da agencia cobradora
           parse.field :agencia_recebedora_com_dv, 168..172
 
           # :especie, 173..174 # especie do titulo
           parse.field :especie_documento, 173..174
 
-          # :tarifa_de_cobranca, 175..187 #valor da despesa de cobranca (ultimos 2 digitos, virgula decimal assumida)
+          # :tarifa_de_cobranca, 175..187 #valor da despesa de cobranca
           parse.field :valor_tarifa, 175..187
 
           # parse.field :outras_despesas, 188..200
           # :juros_operacao_em_atraso, 201..213 # zeros?
 
-          # :valor_do_iof, 214..226 #valor do iof a ser recolhido (ultimos 2 digitos, virgula decimal assumida)
+          # :valor_do_iof, 214..226 #valor do iof a ser recolhido
           parse.field :iof, 214..226
 
-          # :valor_abatimento, 227..239 #valor do abatimento concedido (ultimos 2 digitos, virgula decimal assumida)
+          # :valor_abatimento, 227..239 #valor do abatimento concedido
           parse.field :valor_abatimento, 227..239
 
-          # :descontos, 240..252 #valor do desconto concedido (ultimos 2 digitos, virgula decimal assumida)
+          # :descontos, 240..252 #valor do desconto concedido
           parse.field :desconto, 240..252
 
-          # :valor_principal, 253..265 #valor lancado em conta corrente (ultimos 2 digitos, virgula decimal assumida)
+          # :valor_principal, 253..265 #valor lancado em conta corrente
           parse.field :valor_recebido, 253..265
 
-          # :juros_mora_multa, 266..278 #valor de mora e multa pagos pelo sacado (ultimos 2 digitos, virgula decimal assumida)
+          # :juros_mora_multa, 266..278 #valor de mora multa pagos pelo sacado
           parse.field :juros_mora, 266..278
 
-          # :outros_creditos, 279..291 #valor de outros creditos (ultimos 2 digitos, virgula decimal assumida)
+          # :outros_creditos, 279..291 #valor de outros creditos
           parse.field :outros_recebimento, 279..291
 
           # :brancos, 292..292 #complemento de registro
@@ -102,15 +104,15 @@ module Brcobranca
           # :nome_do_sacado, 302..337 #Nome do sacado
           # :identificador_complemento, 338..338 #Identificador do Complemento
           # :unidade_moeda, 339..340 #Unidade de valor moeda corrente
-          # :valor_titulo_unidade, 341..353 #Valor do título em outra unidade de valor
-          # :valor_ioc_unidade, 354..366 #Valor do IOC em outra unidade de valor
-          # :valor_debito_credito, 367..379 #Valor do débito ou crédito
-          # :tipo_credito/débito (d/c), 380..380 #tipo crédito/débito (d/c)
+          # :valor_titulo_unidade, 341..353 #Valor do titulo unidade de valor
+          # :valor_ioc_unidade, 354..366 #Valor do IOC outra unidade de valor
+          # :valor_debito_credito, 367..379 #Valor do debito ou credito
+          # :tipo_credito/debito (d/c), 380..380 #tipo credito/debito (d/c)
           # :brancos, 381..383 #Brancos
           # :complemento, 384..385 #Complemento
           # :sigla_empresa, 386..389 #Sigla da empresa no sistema
           # :brancos, 390..391 #Brancos
-          # :numero_versão, 392..394 #Número da versão
+          # :numero_versao, 392..394 #Número da versao
 
           # :numero_sequencial, 394..399 #numero sequencial no arquivo
           parse.field :sequencial, 394..399

--- a/lib/brcobranca/retorno/retorno_cnab240.rb
+++ b/lib/brcobranca/retorno/retorno_cnab240.rb
@@ -41,7 +41,7 @@ module Brcobranca
       class Line < Base
         extend ParseLine::FixedWidth # Extendendo parseline
 
-        REGISTRO_T_FIELDS = %w(agencia_com_dv cedente_com_dv nosso_numero carteira data_vencimento valor_titulo banco_recebedor agencia_recebedora_com_dv sequencial valor_tarifa).freeze
+        REGISTRO_T_FIELDS = %w(motivos_de_ocorrencia agencia_com_dv cedente_com_dv nosso_numero carteira data_vencimento valor_titulo banco_recebedor agencia_recebedora_com_dv sequencial valor_tarifa cod_de_ocorrencia motivos_de_ocorrencia).freeze
         REGISTRO_U_FIELDS = %w(desconto_concedito valor_abatimento iof_desconto juros_mora valor_recebido outras_despesas outros_recebimento data_credito data_ocorrencia).freeze
 
         attr_accessor :tipo_registro


### PR DESCRIPTION
Aceitar Juros e Multa em Bradesco, Itaú, Caixa, Banco do Brasil e Santander.
Ler arquivo retorno de Santander e Banco do Brasil.
Preencher o código de motivo das ocorrências na leitura do retorno
