### PR TITLE
Corrige calculo de digito verificador de agencia para sicoob

### DIFF
--- a/lib/brcobranca/remessa/cnab400/sicoob.rb
+++ b/lib/brcobranca/remessa/cnab400/sicoob.rb
@@ -80,7 +80,7 @@ module Brcobranca
         def digito_agencia
           # utilizando a agencia com 4 digitos
           # para calcular o digito
-          agencia.modulo11(mapeamento: { 10 => 'X' }).to_s
+          agencia.modulo11(mapeamento: { 10 => '0' }).to_s
         end
 
         # Complemento do header

--- a/spec/brcobranca/remessa/cnab240/sicoob_spec.rb
+++ b/spec/brcobranca/remessa/cnab240/sicoob_spec.rb
@@ -113,30 +113,30 @@ RSpec.describe Brcobranca::Remessa::Cnab240::Sicoob do
       # =         36 24 14 6 = 80
       # 80 / 11 = 7 com resto 3
       expected_digito_agencia_list = [
-        { agencia: '3214', dv: '0'},
-        { agencia: '2006', dv: '0'},
-        { agencia: '5651', dv: '0'},
-        { agencia: '5691', dv: '0'},
-        { agencia: '5741', dv: '0'},
-        { agencia: '1008', dv: '1'},
-        { agencia: '5681', dv: '2'},
-        { agencia: '5731', dv: '2'},
-        { agencia: '4327', dv: '3'},
-        { agencia: '1001', dv: '4'},
-        { agencia: '5761', dv: '4'},
-        { agencia: '3032', dv: '5'},
-        { agencia: '5671', dv: '5'},
-        { agencia: '5631', dv: '6'},
-        { agencia: '1005', dv: '7'},
-        { agencia: '5661', dv: '8'},
-        { agencia: '0001', dv: '9'},
-        { agencia: '5621', dv: '9'},
+        { agencia: "3214", dv: "0" },
+        { agencia: "2006", dv: "0" },
+        { agencia: "5651", dv: "0" },
+        { agencia: "5691", dv: "0" },
+        { agencia: "5741", dv: "0" },
+        { agencia: "1008", dv: "1" },
+        { agencia: "5681", dv: "2" },
+        { agencia: "5731", dv: "2" },
+        { agencia: "4327", dv: "3" },
+        { agencia: "1001", dv: "4" },
+        { agencia: "5761", dv: "4" },
+        { agencia: "3032", dv: "5" },
+        { agencia: "5671", dv: "5" },
+        { agencia: "5631", dv: "6" },
+        { agencia: "1005", dv: "7" },
+        { agencia: "5661", dv: "8" },
+        { agencia: "0001", dv: "9" },
+        { agencia: "5621", dv: "9" },
       ]
 
-      expected_digito_agencia_list.each do |expected_digito_agencia|
-        remessa_params = params.merge!(agencia: expected_digito_agencia[:agencia])
+      expected_digito_agencia_list.each do |expected_dv_agencia|
+        remessa_params = params.merge!(agencia: expected_dv_agencia[:agencia])
         remessa = subject.class.new(remessa_params)
-        expect(remessa.digito_agencia).to eq expected_digito_agencia[:dv]
+        expect(remessa.digito_agencia).to eq expected_dv_agencia[:dv]
       end
     end
 

--- a/spec/brcobranca/remessa/cnab240/sicoob_spec.rb
+++ b/spec/brcobranca/remessa/cnab240/sicoob_spec.rb
@@ -112,19 +112,32 @@ RSpec.describe Brcobranca::Remessa::Cnab240::Sicoob do
       # x         9  8  7  6
       # =         36 24 14 6 = 80
       # 80 / 11 = 7 com resto 3
-      expect(sicoob.digito_agencia).to eq '3'
+      expected_digito_agencia_list = [
+        { agencia: '3214', dv: '0'},
+        { agencia: '2006', dv: '0'},
+        { agencia: '5651', dv: '0'},
+        { agencia: '5691', dv: '0'},
+        { agencia: '5741', dv: '0'},
+        { agencia: '1008', dv: '1'},
+        { agencia: '5681', dv: '2'},
+        { agencia: '5731', dv: '2'},
+        { agencia: '4327', dv: '3'},
+        { agencia: '1001', dv: '4'},
+        { agencia: '5761', dv: '4'},
+        { agencia: '3032', dv: '5'},
+        { agencia: '5671', dv: '5'},
+        { agencia: '5631', dv: '6'},
+        { agencia: '1005', dv: '7'},
+        { agencia: '5661', dv: '8'},
+        { agencia: '0001', dv: '9'},
+        { agencia: '5621', dv: '9'},
+      ]
 
-      sicoob_2 = subject.class.new(params.merge!(agencia: '3214'))
-      expect(sicoob_2.digito_agencia).to eq '0'
-
-      sicoob_3 = subject.class.new(params.merge!(agencia: '0001'))
-      expect(sicoob_3.digito_agencia).to eq '9'
-
-      sicoob_4 = subject.class.new(params.merge!(agencia: '2006'))
-      expect(sicoob_4.digito_agencia).to eq '0'
-
-      sicoob_5 = subject.class.new(params.merge!(agencia: '3032'))
-      expect(sicoob_5.digito_agencia).to eq '5'
+      expected_digito_agencia_list.each do |expected_digito_agencia|
+        remessa_params = params.merge!(agencia: expected_digito_agencia[:agencia])
+        remessa = subject.class.new(remessa_params)
+        expect(remessa.digito_agencia).to eq expected_digito_agencia[:dv]
+      end
     end
 
     it 'deve calcular  digito da conta' do

--- a/spec/brcobranca/remessa/cnab400/sicoob_spec.rb
+++ b/spec/brcobranca/remessa/cnab400/sicoob_spec.rb
@@ -141,6 +141,43 @@ RSpec.describe Brcobranca::Remessa::Cnab400::Sicoob do
       expect(id_empresa[5..13]).to eq '123456789' # convenio
       expect(id_empresa[14..19]).to eq '      ' # brancos
     end
+
+    it 'deve calcular o digito da agencia' do
+      # digito calculado a partir do modulo 11 com base 9
+      #
+      # agencia = 1  2  3  4
+      #
+      #           4  3  2  1
+      # x         9  8  7  6
+      # =         36 24 14 6 = 80
+      # 80 / 11 = 7 com resto 3
+      expected_digito_agencia_list = [
+        { agencia: '3214', dv: '0'},
+        { agencia: '2006', dv: '0'},
+        { agencia: '5651', dv: '0'},
+        { agencia: '5691', dv: '0'},
+        { agencia: '5741', dv: '0'},
+        { agencia: '1008', dv: '1'},
+        { agencia: '5681', dv: '2'},
+        { agencia: '5731', dv: '2'},
+        { agencia: '4327', dv: '3'},
+        { agencia: '1001', dv: '4'},
+        { agencia: '5761', dv: '4'},
+        { agencia: '3032', dv: '5'},
+        { agencia: '5671', dv: '5'},
+        { agencia: '5631', dv: '6'},
+        { agencia: '1005', dv: '7'},
+        { agencia: '5661', dv: '8'},
+        { agencia: '0001', dv: '9'},
+        { agencia: '5621', dv: '9'},
+      ]
+
+      expected_digito_agencia_list.each do |expected_digito_agencia|
+        remessa_params = params.merge!(agencia: expected_digito_agencia[:agencia])
+        remessa = subject.class.new(remessa_params)
+        expect(remessa.digito_agencia).to eq expected_digito_agencia[:dv]
+      end
+    end
   end
 
   context 'monta remessa' do

--- a/spec/brcobranca/remessa/cnab400/sicoob_spec.rb
+++ b/spec/brcobranca/remessa/cnab400/sicoob_spec.rb
@@ -152,30 +152,30 @@ RSpec.describe Brcobranca::Remessa::Cnab400::Sicoob do
       # =         36 24 14 6 = 80
       # 80 / 11 = 7 com resto 3
       expected_digito_agencia_list = [
-        { agencia: '3214', dv: '0'},
-        { agencia: '2006', dv: '0'},
-        { agencia: '5651', dv: '0'},
-        { agencia: '5691', dv: '0'},
-        { agencia: '5741', dv: '0'},
-        { agencia: '1008', dv: '1'},
-        { agencia: '5681', dv: '2'},
-        { agencia: '5731', dv: '2'},
-        { agencia: '4327', dv: '3'},
-        { agencia: '1001', dv: '4'},
-        { agencia: '5761', dv: '4'},
-        { agencia: '3032', dv: '5'},
-        { agencia: '5671', dv: '5'},
-        { agencia: '5631', dv: '6'},
-        { agencia: '1005', dv: '7'},
-        { agencia: '5661', dv: '8'},
-        { agencia: '0001', dv: '9'},
-        { agencia: '5621', dv: '9'},
+        { agencia: "3214", dv: "0" },
+        { agencia: "2006", dv: "0" },
+        { agencia: "5651", dv: "0" },
+        { agencia: "5691", dv: "0" },
+        { agencia: "5741", dv: "0" },
+        { agencia: "1008", dv: "1" },
+        { agencia: "5681", dv: "2" },
+        { agencia: "5731", dv: "2" },
+        { agencia: "4327", dv: "3" },
+        { agencia: "1001", dv: "4" },
+        { agencia: "5761", dv: "4" },
+        { agencia: "3032", dv: "5" },
+        { agencia: "5671", dv: "5" },
+        { agencia: "5631", dv: "6" },
+        { agencia: "1005", dv: "7" },
+        { agencia: "5661", dv: "8" },
+        { agencia: "0001", dv: "9" },
+        { agencia: "5621", dv: "9" },
       ]
 
-      expected_digito_agencia_list.each do |expected_digito_agencia|
-        remessa_params = params.merge!(agencia: expected_digito_agencia[:agencia])
+      expected_digito_agencia_list.each do |expected_dv_agencia|
+        remessa_params = params.merge!(agencia: expected_dv_agencia[:agencia])
         remessa = subject.class.new(remessa_params)
-        expect(remessa.digito_agencia).to eq expected_digito_agencia[:dv]
+        expect(remessa.digito_agencia).to eq expected_dv_agencia[:dv]
       end
     end
   end


### PR DESCRIPTION
Ajusta o calcular do DV da cooperativa Sicoob. A gem está mapeando para X sendo que deveria estar mapeando para 0.

Por exemplo:
Segundo a documentação do banco, a agência '3214' tem DV '0'