### PR TITLE
Adiciona atributo linha_digitavel

### DIFF
--- a/lib/brcobranca/boleto/base.rb
+++ b/lib/brcobranca/boleto/base.rb
@@ -88,6 +88,8 @@ module Brcobranca
       attr_accessor :avalista_documento
       # <b>OPCIONAL</b>: Endereço do beneficiário
       attr_accessor :cedente_endereco
+      # <b>OPCIONAL</b>: linha digitável
+      attr_accessor :linha_digitavel
 
       # Validações
       validates_presence_of :agencia, :conta_corrente, :moeda, :especie_documento, :especie, :aceite, :nosso_numero, :sacado, :sacado_documento, message: 'não pode estar em branco.'

--- a/lib/brcobranca/boleto/template/rghost.rb
+++ b/lib/brcobranca/boleto/template/rghost.rb
@@ -147,7 +147,7 @@ module Brcobranca
           move_more(doc, 4.84, 0.02)
           doc.show "#{boleto.banco}-#{boleto.banco_dv}", tag: :maior
           move_more(doc, 2, 0)
-          doc.show boleto.codigo_barras.linha_digitavel, tag: :grande
+          doc.show exibe_linha_digitavel_para(boleto), tag: :grande
           move_more(doc, -6.5, -0.83)
 
           doc.show boleto.cedente
@@ -203,7 +203,7 @@ module Brcobranca
           doc.show "#{boleto.banco}-#{boleto.banco_dv}", tag: :maior
 
           move_more(doc, 2, 0)
-          doc.show boleto.codigo_barras.linha_digitavel, tag: :grande
+          doc.show exibe_linha_digitavel_para(boleto), tag: :grande
 
           move_more(doc, -6.5, -0.9)
           doc.show boleto.local_pagamento
@@ -291,6 +291,10 @@ module Brcobranca
             doc.show "#{boleto.avalista} - #{boleto.avalista_documento}"
           end
           # FIM Segunda parte do BOLETO
+        end
+
+        def exibe_linha_digitavel_para(boleto)
+          boleto.linha_digitavel || boleto.codigo_barras.linha_digitavel
         end
       end # Base
     end

--- a/lib/brcobranca/boleto/template/rghost_carne.rb
+++ b/lib/brcobranca/boleto/template/rghost_carne.rb
@@ -216,7 +216,7 @@ module Brcobranca
 
           # linha digitavel
           doc.moveto x: colunas[6], y: linhas[0]
-          doc.show boleto.codigo_barras.linha_digitavel, tag: :media
+          doc.show exibe_linha_digitavel_para(boleto), tag: :media
 
           # local de pagamento
           doc.moveto x: colunas[2], y: linhas[1]
@@ -306,6 +306,10 @@ module Brcobranca
           # codigo de barras
           # Gerando codigo de barra com rghost_barcode
           doc.barcode_interleaved2of5(boleto.codigo_barras, width: '10.3 cm', height: '1.2 cm', x: colunas[2], y: linhas[14]) if boleto.codigo_barras
+        end
+
+        def exibe_linha_digitavel_para(boleto)
+          boleto.linha_digitavel || boleto.codigo_barras.linha_digitavel
         end
       end # Base
     end

--- a/spec/brcobranca/boleto/santander_spec.rb
+++ b/spec/brcobranca/boleto/santander_spec.rb
@@ -75,6 +75,12 @@ RSpec.describe Brcobranca::Boleto::Santander do
     expect(boleto_novo.codigo_barras.linha_digitavel).to eql('03399.18997 77500.000904 00272.501024 3 54500000005400')
   end
 
+  it 'Usa linha digitavel passada' do
+    @valid_attributes[:linha_digitavel] = '11111.22222 33333.444444 55555.666666 7 888888888888'
+    boleto_novo = described_class.new(@valid_attributes)
+    expect(boleto_novo.linha_digitavel).to eq('11111.22222 33333.444444 55555.666666 7 888888888888')
+  end
+
   it 'Não permitir gerar boleto com atributos inválido' do
     boleto_novo = described_class.new
     expect { boleto_novo.codigo_barras }.to raise_error(Brcobranca::BoletoInvalido)


### PR DESCRIPTION
Algumas integrações requerem que os boletos sejam gerados usando uma linha digitavel enviada pelo parceiro.