### PR TITLE
carteira_label no carne

### DIFF
--- a/lib/brcobranca/boleto/template/rghost.rb
+++ b/lib/brcobranca/boleto/template/rghost.rb
@@ -247,7 +247,7 @@ module Brcobranca
           if boleto.variacao
             doc.show "#{boleto.carteira}-#{boleto.variacao}"
           else
-            doc.show boleto.carteira_label
+            doc.show (boleto.carteira_label || boleto.carteira)
           end
 
           move_more(doc, 2, 0)

--- a/lib/brcobranca/boleto/template/rghost.rb
+++ b/lib/brcobranca/boleto/template/rghost.rb
@@ -247,7 +247,7 @@ module Brcobranca
           if boleto.variacao
             doc.show "#{boleto.carteira}-#{boleto.variacao}"
           else
-            doc.show boleto.carteira
+            doc.show boleto.carteira_label
           end
 
           move_more(doc, 2, 0)

--- a/lib/brcobranca/boleto/template/rghost_carne.rb
+++ b/lib/brcobranca/boleto/template/rghost_carne.rb
@@ -263,7 +263,7 @@ module Brcobranca
 
           # carteira
           doc.moveto x: colunas[3], y: linhas[4]
-          doc.show boleto.carteira_label
+          doc.show (boleto.carteira_label || boleto.carteira)
 
           # especie
           doc.moveto x: colunas[5], y: linhas[4]

--- a/lib/brcobranca/boleto/template/rghost_carne.rb
+++ b/lib/brcobranca/boleto/template/rghost_carne.rb
@@ -263,7 +263,7 @@ module Brcobranca
 
           # carteira
           doc.moveto x: colunas[3], y: linhas[4]
-          doc.show boleto.carteira
+          doc.show boleto.carteira_label
 
           # especie
           doc.moveto x: colunas[5], y: linhas[4]


### PR DESCRIPTION
carteira_label no carne, antes printava como: 1, invalidando com o Banco.
![captura de tela 2018-07-24 as 16 59 53](https://user-images.githubusercontent.com/1430869/43163155-9ab9d9b8-8f63-11e8-96a9-132f25eac06e.png)
