### PR TITLE
Ajustes na função de formatar string para campo de remessa

### DIFF
--- a/lib/brcobranca/formatacao_string.rb
+++ b/lib/brcobranca/formatacao_string.rb
@@ -8,10 +8,11 @@ module Brcobranca
     # se a string for maior, trunca para o num. de caracteres
     #
     def format_size(size)
-      if self.size > size
-        remove_accents.strip.gsub(/\s+/, ' ').gsub(/[^A-Za-z0-9[[:space:]]]/, '').truncate(size)
+      clean_str = remove_accents.strip.gsub(/\s+/, ' ').gsub(/[^A-Za-z0-9[[:space:]]]/, '')
+      if clean_str.size > size
+        clean_str.truncate(size)
       else
-        remove_accents.strip.gsub(/\s+/, ' ').gsub(/[^A-Za-z0-9[[:space:]]]/, '').ljust(size, ' ')
+        clean_str.ljust(size, ' ')
       end
     end
 

--- a/spec/brcobranca/formatacao_string_spec.rb
+++ b/spec/brcobranca/formatacao_string_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Brcobranca::FormatacaoString do
   context 'above size' do
     it { expect("SOÇIEDADE,  BRASI@?!+-_LEIR'\"A DE ZÔÔLOGIA LTDA.".format_size(30)).to eql('SOCIEDADE BRASILEIRA DE ZOOLOG') }
     it { expect('pablo diego JOSÉ FRANCISCO DE PAULA JUAN'.format_size(30)).to eql('pablo diego JOSE FRANCISCO DE ') }
+    it { expect('DF 250, KM 4 Cond. La Foret , Qd. M Casa 03'.format_size(40)).to eql('DF 250 KM 4 Cond La Foret  Qd M Casa 03 ') }
   end
 
   context 'bellow size' do


### PR DESCRIPTION
Segue teste mostrando o erro e correção para campos que possuem tamanho maior que o limite antes da limpeza e menor que o limite após.