### PR TITLE
Validar presenca do campo bairro_sacado na classe pagamento de remessa

### DIFF
--- a/lib/brcobranca/remessa/pagamento.rb
+++ b/lib/brcobranca/remessa/pagamento.rb
@@ -87,8 +87,9 @@ module Brcobranca
       attr_accessor :parcela
 
       validates_presence_of :nosso_numero, :data_vencimento, :valor,
-        :documento_sacado, :nome_sacado, :endereco_sacado,
-        :cep_sacado, :cidade_sacado, :uf_sacado, message: 'não pode estar em branco.'
+                            :documento_sacado, :nome_sacado, :endereco_sacado,
+                            :bairro_sacado, :cep_sacado, :cidade_sacado,
+                            :uf_sacado, message: "não pode estar em branco."
       validates_length_of :uf_sacado, is: 2, message: 'deve ter 2 dígitos.'
       validates_length_of :cep_sacado, is: 8, message: 'deve ter 8 dígitos.'
       validates_length_of :cod_desconto, is: 1, message: 'deve ter 1 dígito.'

--- a/spec/brcobranca/remessa/pagamento_spec.rb
+++ b/spec/brcobranca/remessa/pagamento_spec.rb
@@ -58,6 +58,12 @@ RSpec.describe Brcobranca::Remessa::Pagamento do
       expect(pagamento.errors.full_messages).to include('Cidade sacado não pode estar em branco.')
     end
 
+    it "deve ser invalido se nao possuir bairro do sacado" do
+      pagamento.bairro_sacado = nil
+      expect(pagamento.invalid?).to be true
+      expect(pagamento.errors.full_messages).to include("Bairro sacado não pode estar em branco.")
+    end
+
     it 'deve ser invalido se nao possuir UF do sacado' do
       pagamento.uf_sacado = nil
       expect(pagamento.invalid?).to be true


### PR DESCRIPTION
Campo bairro_sacado é requerido para pagamento de remessa, porém sua presenca nao está sendo validada.