### PR TITLE
Bradesco CNAB400: Adiciona suporte ao 2º e 3º desconto

### DIFF
--- a/lib/brcobranca/remessa/cnab400/base.rb
+++ b/lib/brcobranca/remessa/cnab400/base.rb
@@ -73,6 +73,12 @@ module Brcobranca
               contador += 1
               ret << monta_detalhe_multa(pagamento, contador)
             end
+
+            # Adiciona registro de desconto adicional
+            if pagamento.valor_segundo_desconto.to_f > 0 && self.respond_to?(:monta_descontos_adicionais)
+              contador += 1
+              ret << monta_descontos_adicionais(pagamento, contador)
+            end
           end
           ret << monta_trailer(contador + 1)
 

--- a/lib/brcobranca/remessa/cnab400/bradesco.rb
+++ b/lib/brcobranca/remessa/cnab400/bradesco.rb
@@ -124,6 +124,29 @@ module Brcobranca
           detalhe << sequencial.to_s.rjust(6, '0')                    # numero do registro do arquivo               9[06]       395 a 400
           detalhe
         end
+
+        def monta_descontos_adicionais(pagamento, sequencial)
+          raise Brcobranca::RemessaInvalida, pagamento if pagamento.invalid?
+
+          detalhe = '2'                                                  # identificacao do registro                   9[01]       001 a 001
+          detalhe << ''.rjust(80, ' ')                                   # mensagem 1                                  X[80]       002 a 081
+          detalhe << ''.rjust(80, ' ')                                   # mensagem 2                                  X[80]       082 a 161
+          detalhe << ''.rjust(80, ' ')                                   # mensagem 3                                  X[80]       162 a 241
+          detalhe << ''.rjust(80, ' ')                                   # mensagem 4                                  X[80]       242 a 321
+          detalhe << pagamento.formata_data_segundo_desconto             # data limite para o terceiro desconto        9[06]       322 a 327
+          detalhe << pagamento.formata_valor_segundo_desconto            # valor do segundo desconto                   9[13]       328 a 340
+          detalhe << pagamento.formata_data_terceiro_desconto            # data limite para o terceiro desconto        9[06]       341 a 346
+          detalhe << pagamento.formata_valor_terceiro_desconto           # valor do terceiro desconto                  9[13]       347 a 359
+          detalhe << ''.rjust(7, ' ')                                    # reserva                                     X[07]       360 a 366
+          detalhe << carteira.to_s.rjust(3, '0')                         # carteira                                    9[03]       367 a 369
+          detalhe << agencia                                             # codigo da agencia (sem dv)                  9[05]       370 a 374
+          detalhe << conta_corrente                                      # codigo da conta                             9[07]       375 a 381
+          detalhe << digito_conta                                        # digito da conta                             X[01]       382 a 382
+          detalhe << pagamento.nosso_numero.to_s.rjust(11, '0')          # identificacao do titulo (nosso numero)      9[11]       383 a 393
+          detalhe << digito_nosso_numero(pagamento.nosso_numero).to_s    # digito de conferencia do nosso numero (dv)  X[01]       394 a 394
+          detalhe << sequencial.to_s.rjust(6, '0')                       # numero do registro do arquivo               9[06]       395 a 400
+          detalhe
+        end
       end
     end
   end

--- a/lib/brcobranca/remessa/pagamento.rb
+++ b/lib/brcobranca/remessa/pagamento.rb
@@ -61,6 +61,10 @@ module Brcobranca
       attr_accessor :data_segundo_desconto
       # <b>OPCIONAL</b>: valor a ser concedido de desconto
       attr_accessor :valor_segundo_desconto
+      # <b>OPCIONAL</b>: data limite para o terceiro desconto
+      attr_accessor :data_terceiro_desconto
+      # <b>OPCIONAL</b>: valor a ser concedido de desconto
+      attr_accessor :valor_terceiro_desconto
       # <b>OPCIONAL</b>: espécie do título
       attr_accessor :especie_titulo
       # <b>OPCIONAL</b>: código da multa
@@ -103,10 +107,12 @@ module Brcobranca
         padrao = {
           data_emissao: Date.current,
           data_segundo_desconto:'00-00-00',
+          data_terceiro_desconto:'00-00-00',
           tipo_mora: "3",
           valor_mora: 0.0,
           valor_desconto: 0.0,
           valor_segundo_desconto: 0.0,
+          valor_terceiro_desconto: 0.0,
           valor_iof: 0.0,
           valor_abatimento: 0.0,
           nome_avalista: '',
@@ -152,6 +158,20 @@ module Brcobranca
       #
       def formata_data_segundo_desconto(formato = '%d%m%y')
         data_segundo_desconto.strftime(formato)
+      rescue
+        if formato == '%d%m%y'
+          '000000'
+        else
+          '00000000'
+        end
+      end
+
+      # Formata a data de terceiro desconto de acordo com o formato passado
+      #
+      # @return [String]
+      #
+      def formata_data_terceiro_desconto(formato = '%d%m%y')
+        data_terceiro_desconto.strftime(formato)
       rescue
         if formato == '%d%m%y'
           '000000'
@@ -239,6 +259,15 @@ module Brcobranca
       #
       def formata_valor_segundo_desconto(tamanho = 13)
         format_value(valor_segundo_desconto, tamanho)
+      end
+
+      # Formata o campo valor do terceiro desconto
+      #
+      # @param tamanho [Integer]
+      #   quantidade de caracteres a ser retornado
+      #
+      def formata_valor_terceiro_desconto(tamanho = 13)
+        format_value(valor_terceiro_desconto, tamanho)
       end
 
       # Formata o campo valor do IOF


### PR DESCRIPTION
# Adiciona suporte ao 2º e 3º desconto a Remessa CNAB400 do Bradesco

### Motivo:
Em um dos meus projetos o cliente precisa que o boleto tenha 3 datas de descontos que vão diminuindo ao passar das datas.
Ex:
  - Vencimento: 31/07
  - 1º desconto: 10/07 >> 50% de desconto
  - 2º desconto: 20/07 >> 40% de desconto
  - 3º desconto: 25/07 >> 30% de desconto

### Modo de usar

```ruby
pagamento_attrs = {}

if boleto.valor_segundo_desconto.to_f.positive? && boleto.data_segundo_desconto.present?
  pagamento_attrs[:data_segundo_desconto] =  boleto.data_segundo_desconto
  pagamento_attrs[:valor_segundo_desconto] = boleto.valor_segundo_desconto.to_f
end

if boleto.valor_terceiro_desconto.to_f.positive? && boleto.data_terceiro_desconto.present?
  pagamento_attrs[:data_terceiro_desconto] = boleto.data_vencimento
  pagamento_attrs[:valor_terceiro_desconto] = boleto.valor_terceiro_desconto.to_f
end

pagamento = Brcobranca::Remessa::Pagamento.new(pagamento_attrs)
```

Informações sobre o 2º e 3º desconto, podem ser encontrados em: **_(Página 11)_**
https://banco.bradesco/assets/pessoajuridica/pdf/mpo_arquivos_layout_400P.pdf
