### PR TITLE
[FIX] Boleto Unicred 400, é preciso incluir o campo Banco DV no Codigo de Barras

### DIFF
--- a/lib/brcobranca/boleto/unicred.rb
+++ b/lib/brcobranca/boleto/unicred.rb
@@ -91,6 +91,15 @@ module Brcobranca
       # 24-33 | 10 | 10 | Conta do BENEFICIÁRIO (Com o dígito verificador)
       # 34–44 | 11 | 11 | Nosso Número (Com o dígito verificador)
       # @return [String] 25 caracteres numéricos.
+      def banco_dv
+        "8"
+      end
+
+      def codigo_barras_primeira_parte
+        # Herança necessário para informar o quinto caracter Banco DV
+        "#{banco}#{moeda}#{banco_dv}#{fator_vencimento}#{valor_documento_formatado}"
+      end
+
       def codigo_barras_segunda_parte
         "#{agencia}#{conta_corrente}#{conta_corrente_dv}#{nosso_numero}#{nosso_numero_dv}"
       end


### PR DESCRIPTION
No caso do Boleto Unicred 400, é preciso incluir o campo Banco DV no Código de Barras, sem essa alteração ao tentar gerar o Boleto ocorre erro aqui https://github.com/kivanio/brcobranca/blob/master/lib/brcobranca/boleto/base.rb#L208 devido o tamanho ser menor( um caracter a menos do que o esperado ).

De acordo com a documentação https://github.com/kivanio/brcobranca/blob/master/docs/unicred/GR%20-%20COB136%20-%20Composi%C3%A7%C3%A3o%20da%20Ficha%20de%20Compensa%C3%A7%C3%A3o%2003DEZ2019.pdf o valor do campo deve ser 8 

![image](https://user-images.githubusercontent.com/6341149/177376009-967944dd-4808-47af-ad1b-2181abd0f86d.png)

![image](https://user-images.githubusercontent.com/6341149/177376147-4880a24d-821a-4cdd-bea7-c9a33c2387c8.png)
