### PR TITLE
Correção do local de pagamento para o Banco do Brasil

### DIFF
--- a/lib/brcobranca/boleto/banco_brasil.rb
+++ b/lib/brcobranca/boleto/banco_brasil.rb
@@ -29,7 +29,11 @@ module Brcobranca
       # Nova instancia do BancoBrasil
       # @param (see Brcobranca::Boleto::Base#initialize)
       def initialize(campos = {})
-        campos = { carteira: '18', codigo_servico: false }.merge!(campos)
+        campos = { 
+          carteira: '18', 
+          codigo_servico: false, 
+          local_pagamento: 'PAGÁVEL EM QUALQUER BANCO.'
+        }.merge!(campos)       
         super(campos)
       end
 

--- a/spec/brcobranca/boleto/banco_brasil_spec.rb
+++ b/spec/brcobranca/boleto/banco_brasil_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Brcobranca::Boleto::BancoBrasil do # :nodoc:[all]
   before do
     @valid_attributes = {
       valor: 0.0,
-      local_pagamento: 'QUALQUER BANCO ATÉ O VENCIMENTO',
+      local_pagamento: 'PAGÁVEL EM QUALQUER BANCO.',
       cedente: 'Kivanio Barbosa',
       documento_cedente: '12345678912',
       sacado: 'Claudio Pozzebom',
@@ -30,7 +30,7 @@ RSpec.describe Brcobranca::Boleto::BancoBrasil do # :nodoc:[all]
     expect(boleto_novo.quantidade).to be(1)
     expect(boleto_novo.valor).to eq(0.0)
     expect(boleto_novo.valor_documento).to eq(0.0)
-    expect(boleto_novo.local_pagamento).to eql('QUALQUER BANCO ATÉ O VENCIMENTO')
+    expect(boleto_novo.local_pagamento).to eql('PAGÁVEL EM QUALQUER BANCO.')
     expect(boleto_novo.carteira).to eql('18')
     expect(boleto_novo.codigo_servico).to be_falsey
   end
@@ -47,7 +47,7 @@ RSpec.describe Brcobranca::Boleto::BancoBrasil do # :nodoc:[all]
     expect(boleto_novo.quantidade).to be(1)
     expect(boleto_novo.valor).to eq(0.0)
     expect(boleto_novo.valor_documento).to eq(0.0)
-    expect(boleto_novo.local_pagamento).to eql('QUALQUER BANCO ATÉ O VENCIMENTO')
+    expect(boleto_novo.local_pagamento).to eql('PAGÁVEL EM QUALQUER BANCO.')
     expect(boleto_novo.cedente).to eql('Kivanio Barbosa')
     expect(boleto_novo.documento_cedente).to eql('12345678912')
     expect(boleto_novo.sacado).to eql('Claudio Pozzebom')
@@ -202,7 +202,7 @@ RSpec.describe Brcobranca::Boleto::BancoBrasil do # :nodoc:[all]
   it 'Montar código de barras para convenio de 7 digitos e nosso número de 10 e carteira 17' do
     valid_attributes = {
       valor: 2246.74,
-      local_pagamento: 'QUALQUER BANCO ATÉ O VENCIMENTO',
+      local_pagamento: 'PAGÁVEL EM QUALQUER BANCO.',
       cedente: 'Kivanio Barbosa',
       documento_cedente: '12345678912',
       sacado: 'Claudio Pozzebom',


### PR DESCRIPTION
No processo de homologação do boleto Banco do Brasil foi solicitado a correção do local do pagamento:
![image](https://user-images.githubusercontent.com/634278/181141007-05678e12-632e-4ad5-a9e4-e14ac0fb3e51.png)

Apliquei a alteração apenas para o Banco do Brasil pois não sei confirmar se o mesmo é valido para os outros bancos.


