### PR TITLE
Possibilitar pagamento via PIX a partir de leitura de EMV

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,3 +11,7 @@ AllCops:
 
 Style/FrozenStringLiteralComment:
   EnforcedStyle: always
+
+Layout/LineLength:
+  Max: 125
+  IgnoredPatterns: ['\A#']

--- a/lib/brcobranca.rb
+++ b/lib/brcobranca.rb
@@ -121,6 +121,7 @@ module Brcobranca
       autoload :Rghost,      'brcobranca/boleto/template/rghost'
       autoload :Rghost2,     'brcobranca/boleto/template/rghost2'     
       autoload :RghostCarne, 'brcobranca/boleto/template/rghost_carne'
+      autoload :RghostBolepix, 'brcobranca/boleto/template/rghost_bolepix'
     end
   end
 

--- a/lib/brcobranca/boleto/base.rb
+++ b/lib/brcobranca/boleto/base.rb
@@ -89,6 +89,8 @@ module Brcobranca
       attr_accessor :avalista_documento
       # <b>OPCIONAL</b>: Endereço do beneficiário
       attr_accessor :cedente_endereco
+      # <b>OPCIONAL</b>: EMV para gerar QRCode para pagamento via PIX
+      attr_accessor :emv
 
       # Validações
       validates_presence_of :agencia, :conta_corrente, :moeda, :especie_documento, :especie, :aceite, :nosso_numero,

--- a/lib/brcobranca/boleto/template/base.rb
+++ b/lib/brcobranca/boleto/template/base.rb
@@ -12,6 +12,8 @@ module Brcobranca
             [Brcobranca::Boleto::Template::Rghost]
           when :rghost_carne
             [Brcobranca::Boleto::Template::RghostCarne]
+          when :rghost_bolepix
+            [Brcobranca::Boleto::Template::RghostBolepix]
           when :rghost2
             [Brcobranca::Boleto::Template::Rghost2]
           when :both

--- a/lib/brcobranca/boleto/template/rghost.rb
+++ b/lib/brcobranca/boleto/template/rghost.rb
@@ -86,8 +86,10 @@ module Brcobranca
 
           # Gerando QRCode a partir de um emv
           if boleto.emv
-            doc.barcode_qrcode(boleto.emv, width: "2.5 cm", height: "2.5 cm",
-                                           x: "#{@x + 12.9} cm", y: "#{@y - 2.50} cm")
+            doc.barcode_qrcode(boleto.emv, width: "2.5 cm",
+                                           height: "2.5 cm",
+                                           x: "#{@x + 12.9} cm",
+                                           y: "#{@y - 2.50} cm")
             move_more(doc, @x + 12.9, @y - 3.70)
             doc.show "Pague com PIX"
           end
@@ -124,8 +126,10 @@ module Brcobranca
 
             # Gerando QRCode a partir de um emv
             if boleto.emv
-              doc.barcode_qrcode(boleto.emv, width: "2.5 cm", height: "2.5 cm",
-                                             x: "#{@x + 12.9} cm", y: "#{@y - 2.50} cm")
+              doc.barcode_qrcode(boleto.emv, width: "2.5 cm",
+                                             height: "2.5 cm",
+                                             x: "#{@x + 12.9} cm",
+                                             y: "#{@y - 2.50} cm")
               move_more(doc, @x + 12.9, @y - 3.70)
               doc.show "Pague com PIX"
             end

--- a/lib/brcobranca/boleto/template/rghost.rb
+++ b/lib/brcobranca/boleto/template/rghost.rb
@@ -84,6 +84,13 @@ module Brcobranca
             doc.barcode_interleaved2of5(boleto.codigo_barras, width: '10.3 cm', height: '1.3 cm', x: "#{@x - 1.7} cm", y: "#{@y - 1.67} cm")
           end
 
+          # Gerando QRCode a partir de um emv
+          if boleto.emv
+            doc.barcode_qrcode(boleto.emv, width: '2.5 cm', height: '2.5 cm', x: "#{@x+12.9} cm", y: "#{@y - 2.50} cm")
+            move_more(doc, @x + 12.9, @y - 3.70)
+            doc.show 'Pague com PIX'
+          end
+
           # Gerando stream
           formato = (options.delete(:formato) || Brcobranca.configuration.formato)
           resolucao = (options.delete(:resolucao) || Brcobranca.configuration.resolucao)
@@ -112,6 +119,13 @@ module Brcobranca
             # Gerando codigo de barra com rghost_barcode
             if boleto.codigo_barras
               doc.barcode_interleaved2of5(boleto.codigo_barras, width: '10.3 cm', height: '1.3 cm', x: "#{@x - 1.7} cm", y: "#{@y - 1.67} cm")
+            end
+
+            # Gerando QRCode a partir de um emv
+            if boleto.emv
+              doc.barcode_qrcode(boleto.emv, width: '2.5 cm', height: '2.5 cm', x: "#{@x+12.5} cm", y: "#{@y - 2.50} cm")
+              move_more(doc, @x + 12.5, @y - 3.70)
+              doc.show 'Pague com PIX'
             end
 
             # Cria nova página se não for o último boleto

--- a/lib/brcobranca/boleto/template/rghost.rb
+++ b/lib/brcobranca/boleto/template/rghost.rb
@@ -88,7 +88,7 @@ module Brcobranca
           if boleto.emv
             doc.barcode_qrcode(boleto.emv, width: '2.5 cm', height: '2.5 cm', x: "#{@x+12.9} cm", y: "#{@y - 2.50} cm")
             move_more(doc, @x + 12.9, @y - 3.70)
-            doc.show 'Pague com PIX'
+            doc.show "Pague com PIX"
           end
 
           # Gerando stream
@@ -125,7 +125,7 @@ module Brcobranca
             if boleto.emv
               doc.barcode_qrcode(boleto.emv, width: '2.5 cm', height: '2.5 cm', x: "#{@x+12.5} cm", y: "#{@y - 2.50} cm")
               move_more(doc, @x + 12.5, @y - 3.70)
-              doc.show 'Pague com PIX'
+              doc.show "Pague com PIX"
             end
 
             # Cria nova página se não for o último boleto

--- a/lib/brcobranca/boleto/template/rghost.rb
+++ b/lib/brcobranca/boleto/template/rghost.rb
@@ -86,7 +86,8 @@ module Brcobranca
 
           # Gerando QRCode a partir de um emv
           if boleto.emv
-            doc.barcode_qrcode(boleto.emv, width: '2.5 cm', height: '2.5 cm', x: "#{@x+12.9} cm", y: "#{@y - 2.50} cm")
+            doc.barcode_qrcode(boleto.emv, width: "2.5 cm", height: "2.5 cm", 
+                               x: "#{@x + 12.9} cm", y: "#{@y - 2.50} cm")
             move_more(doc, @x + 12.9, @y - 3.70)
             doc.show "Pague com PIX"
           end
@@ -123,8 +124,9 @@ module Brcobranca
 
             # Gerando QRCode a partir de um emv
             if boleto.emv
-              doc.barcode_qrcode(boleto.emv, width: '2.5 cm', height: '2.5 cm', x: "#{@x+12.5} cm", y: "#{@y - 2.50} cm")
-              move_more(doc, @x + 12.5, @y - 3.70)
+              doc.barcode_qrcode(boleto.emv, width: "2.5 cm", height: "2.5 cm", 
+                                 x: "#{@x + 12.9} cm", y: "#{@y - 2.50} cm")
+              move_more(doc, @x + 12.9, @y - 3.70)
               doc.show "Pague com PIX"
             end
 

--- a/lib/brcobranca/boleto/template/rghost.rb
+++ b/lib/brcobranca/boleto/template/rghost.rb
@@ -86,8 +86,8 @@ module Brcobranca
 
           # Gerando QRCode a partir de um emv
           if boleto.emv
-            doc.barcode_qrcode(boleto.emv, width: "2.5 cm", height: "2.5 cm", 
-                               x: "#{@x + 12.9} cm", y: "#{@y - 2.50} cm")
+            doc.barcode_qrcode(boleto.emv, width: "2.5 cm", height: "2.5 cm",
+                                           x: "#{@x + 12.9} cm", y: "#{@y - 2.50} cm")
             move_more(doc, @x + 12.9, @y - 3.70)
             doc.show "Pague com PIX"
           end
@@ -124,8 +124,8 @@ module Brcobranca
 
             # Gerando QRCode a partir de um emv
             if boleto.emv
-              doc.barcode_qrcode(boleto.emv, width: "2.5 cm", height: "2.5 cm", 
-                                 x: "#{@x + 12.9} cm", y: "#{@y - 2.50} cm")
+              doc.barcode_qrcode(boleto.emv, width: "2.5 cm", height: "2.5 cm",
+                                             x: "#{@x + 12.9} cm", y: "#{@y - 2.50} cm")
               move_more(doc, @x + 12.9, @y - 3.70)
               doc.show "Pague com PIX"
             end

--- a/lib/brcobranca/boleto/template/rghost_bolepix.rb
+++ b/lib/brcobranca/boleto/template/rghost_bolepix.rb
@@ -44,7 +44,7 @@ module Brcobranca
         def method_missing(m, *args)
           method = m.to_s
           if method.start_with?('to_')
-            modelo_generico(self, (args.first || {}).merge!(formato: method[3..-1]))
+            modelo_generico(self, (args.first || {}).merge!(formato: method[3..]))
           else
             super
           end
@@ -235,8 +235,10 @@ module Brcobranca
           doc.show boleto.valor_documento.to_currency
 
           if boleto.instrucoes
-            doc.text_area boleto.instrucoes, width: '14 cm', text_align: :left, x: "#{@x -= 15.8} cm",
-                                             y: "#{@y -= 0.9} cm", row_height: '0.4 cm'
+            doc.text_area boleto.instrucoes, width: '14 cm',
+                                             text_align: :left, x: "#{@x -= 15.8} cm",
+                                             y: "#{@y -= 0.9} cm",
+                                             row_height: '0.4 cm'
             move_more(doc, 0, -2)
           else
             move_more(doc, -15.8, -0.9)
@@ -260,7 +262,8 @@ module Brcobranca
 
           move_more(doc, 0.5, -1.9)
           if boleto.sacado && boleto.sacado_documento
-            doc.show "#{boleto.sacado} - CPF/CNPJ: #{boleto.sacado_documento.formata_documento}"
+            sacado_info = "#{boleto.sacado} - CPF/CNPJ: #{boleto.sacado_documento.formata_documento}"
+            doc.show sacado_info
           end
 
           move_more(doc, 0, -0.4)

--- a/lib/brcobranca/boleto/template/rghost_bolepix.rb
+++ b/lib/brcobranca/boleto/template/rghost_bolepix.rb
@@ -44,7 +44,7 @@ module Brcobranca
         def method_missing(m, *args)
           method = m.to_s
           if method.start_with?('to_')
-            modelo_generico(self, (args.first || {}).merge!(formato: method[3..]))
+            modelo_generico(self, (args.first || {}).merge!(formato: method[3..-1]))
           else
             super
           end


### PR DESCRIPTION
Adiciona leitura de EMV para boletos com template de `modelo_generico`. Foi feito apenas para esse modelo por se tratar da minha necessidade atual, por isso `modelo_generico2` e `modelo_carne` ficaram de fora.
Foi testado com um EMV existente e os aplicativos de banco conseguiram ler normalmente. Para fins de visualização, o QRCode do print retorna apenas um texto

<img width="1038" alt="image" src="https://user-images.githubusercontent.com/9660378/220944313-bbf58661-f30e-4bf3-a3ed-e800b3211837.png">
