### PR TITLE
Arrumar o valor do "Seu Número" na Remessa 400 do Banco do Brasil.

### DIFF
--- a/lib/brcobranca/remessa/cnab400/banco_brasil.rb
+++ b/lib/brcobranca/remessa/cnab400/banco_brasil.rb
@@ -120,7 +120,7 @@ module Brcobranca
           detalhe << tipo_cobranca.to_s.ljust(5, ' ')                         # tipo de cobranca                  9[05] 102 a 106
           detalhe << carteira                                                 # carteira                          9[02] 107 a 108
           detalhe << pagamento.identificacao_ocorrencia                       # comando / ocorrência              9[02] 109 a 110
-          detalhe << pagamento.nosso_numero.to_s.rjust(10, '0')               # numero atribuido pela empresa     X[10] 111 a 120
+          detalhe << pagamento.documento_ou_numero.to_s.rjust(10, '0')        # numero atribuido pela empresa     X[10] 111 a 120
           detalhe << pagamento.data_vencimento.strftime('%d%m%y')             # data de vencimento                9[06] 121 a 126
           detalhe << pagamento.formata_valor                                  # valor do titulo                   9[13] 127 a 139
           detalhe << cod_banco                                                # numero do banco                   9[03] 140 a 142


### PR DESCRIPTION
Arruma o **Número atribuído pela empresa** (Seu Número)  para pegar o valor correto, antes estava sendo atribuído o **nosso_numero** erroneamente.