### PR TITLE
Correção da quantidade de dígitos para a conta corrente AILOS

### DIFF
--- a/lib/brcobranca/boleto/ailos.rb
+++ b/lib/brcobranca/boleto/ailos.rb
@@ -5,10 +5,11 @@ module Brcobranca
     # Ailos
     class Ailos < Base
       validates_length_of :agencia, maximum: 4, message: 'deve ser menor ou igual a 4 dígitos.'
-      validates_length_of :conta_corrente, maximum: 7, message: 'deve ser menor ou igual a 7 dígitos.'
+      validates_length_of :conta_corrente,
+                          maximum: 8,
+                          message: "deve ser menor ou igual a 8 dígitos."
       validates_length_of :carteira, is: 2, message: 'deve ser menor ou igual a 2 dígitos.'
       validates_length_of :convenio, is: 6, message: 'deve ser menor ou igual a 6 dígitos.'
-
       validates_length_of :nosso_numero, maximum: 9, message: 'deve ser menor ou igual a 9 dígitos.'
 
       # Nova instancia do Ailos


### PR DESCRIPTION
Altera o comprimento máximo da conta corrente de 7 digitos para 8 dígitos quando for um banco do sistema AILOS.
As novas contas já estão vindo com 8 dígitos. 