### PR TITLE
[DEV] Ruby 3.2.0 precisa usar o rghost na versão 0.9.8 

### DIFF
--- a/brcobranca.gemspec
+++ b/brcobranca.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'activesupport', '>= 5.2.6'
   gem.add_dependency 'parseline', '>= 1.0.3'
-  gem.add_dependency 'rghost', '>= 0.9'
+  gem.add_dependency 'rghost', '>= 0.9.8'
   gem.add_dependency 'rghost_barcode', '>= 0.9'
   gem.metadata = {
     'rubygems_mfa_required' => 'true'


### PR DESCRIPTION
Salve @kivanio 

Estive testando a atualização para o Ruby 3.2.0 e pelo o que entendi foi depreciado o comando exists para exist

https://www.reddit.com/r/ruby/comments/1196wti/psa_and_a_little_rant_fileexists_direxists/?rdt=61177

Por isso para evitar erro é necessário usar a biblioteca rghost na versão 0.9.8, onde essa alteração é feita

https://my.diffend.io/gems/rghost/0.9.7/0.9.8

Testei a alteração na API https://github.com/akretion/boleto_cnab_api e parece estar funcionando sem problemas com essa versão. 