### PR TITLE
Adicionando Logo no template Rghost2 no Recibo do Beneficiário 

### DIFF
--- a/lib/brcobranca/boleto/template/rghost2.rb
+++ b/lib/brcobranca/boleto/template/rghost2.rb
@@ -126,6 +126,7 @@ module Brcobranca
 
         # Monta Recibo do Beneficiário
         def modelo_recibo_beneficiario(doc, boleto)
+          monta_logotipo(doc, boleto, 14.500, 26.850, 1.00)
           doc.moveto x: 4.28, y: 26.87
           doc.show truncar(boleto.cedente, 90), tag: :menor
           doc.moveto x: 4.28, y: 26.33


### PR DESCRIPTION
Objetivo dessa PR é a necessidade de adicionar um logo no recibo do Beneficiário, podemos vê o resultado aqui: 

![image](https://github.com/kivanio/brcobranca/assets/142639425/c4c5a152-0f4e-41ea-b5dd-e94fa060c2c4)

PDF gerado também: 

[boletinho.pdf](https://github.com/kivanio/brcobranca/files/14723930/boletinho.pdf)
