### PR TITLE
[FIX] Santander Remessa 240: Digito da Agência

### DIFF
--- a/lib/brcobranca/remessa/cnab240/santander.rb
+++ b/lib/brcobranca/remessa/cnab240/santander.rb
@@ -12,6 +12,7 @@ module Brcobranca
         validates_length_of :codigo_transmissao, maximum: 15, message: 'deve ter no máximo 15 dígitos.'
         validates_length_of :agencia, maximum: 4, message: 'deve ter 4 dígitos.'
         validates_length_of :conta_corrente, maximum: 9, message: 'deve ter 9 dígitos.'
+        validates_length_of :digito_conta, is: 1, message: 'deve ter 1 dígito.'
 
         def initialize(campos = {})
           campos = {  emissao_boleto: ' ', distribuicao_boleto: ' ',
@@ -26,11 +27,7 @@ module Brcobranca
         def digito_agencia
           agencia.modulo11(mapeamento: { 10 => 'X', 11 => 'X' }).to_s
         end
-
-        def digito_conta
-          conta_corrente.modulo11(mapeamento: { 10 => 'X', 11 => 'X' }).to_s
-        end
-
+       
         def complemento_header
           ''.rjust(29, ' ')
         end


### PR DESCRIPTION
Objetivo:

Correção do cálculo do Código da Conta Corrente para garantir a geração correta do arquivo REM ao consumir a API.

Detalhes:

O cálculo do Código da Conta Corrente estava apresentando falhas quando baseado no módulo 11. Entretanto, ao remover o cálculo, o arquivo REM é gerado corretamente.

Testes Realizados:

-  Número da conta: 01058941
-  Dígito verificador: 2

Antes: 
![image](https://github.com/kivanio/brcobranca/assets/53870822/8b8d1e87-377d-4390-a62d-5d3b412aabed)

Depois:

![image](https://github.com/kivanio/brcobranca/assets/53870822/84139380-7e2d-4e77-b1b4-cd1c35b40009)

Durante os testes, o dígito da conta correto está em conformidade como esperado.

cc @marcelsavegnago @antoniospneto