### PR TITLE
[FIX] itau.rb prazo instrução protesto: 09, 34 e 35

### DIFF
--- a/lib/brcobranca/remessa/cnab400/itau.rb
+++ b/lib/brcobranca/remessa/cnab400/itau.rb
@@ -140,7 +140,9 @@ module Brcobranca
         end
 
         def prazo_instrucao(pagamento)
-          return '03' unless pagamento.cod_primeira_instrucao == '09'
+          return "03" unless %w[09 34 35].include?(
+            pagamento.cod_primeira_instrucao
+          )
 
           pagamento.dias_protesto.rjust(2, '0')
         end


### PR DESCRIPTION
![image](https://github.com/kivanio/brcobranca/assets/1975978/1057b272-567d-46ed-b5b4-760f7e55fd3d)

https://download.itau.com.br/bankline/layout_cobranca_400bytes_cnab_itau.pdf 

Conforme manual, pagina 21 e nota (A)


> (A) Informar a quantidade de dias nas posições 392 a 393. No caso da instrução “42”, o beneficiário
> passa a ter prioridade no recebimento quando o pagador estiver com falência decretada. A
> quantidade de dias será utilizada para as instruções de negativação expressa e protesto, não sendo
> possível informar no arquivo remessa de entrada as instruções de negativação e protesto,
> simultaneamente para o mesmo título. Se forem enviadas as duas instruções, a única a ser
> considerada será a instrução da negativação. Na negativação, caso o campo quantidade de dias seja
> informado com zeros, será considerado o prazo de 2 (dois) dias corridos após o vencimento.
> No caso da instrução “39”, se informar “00” será impresso no boleto a literal “NÃO RECEBER APÓS
> O VENCIMENTO”