### PR TITLE
Adiciona a renderização dos valores de descontos/abatimentos nos campos devidos do boleto.

### DIFF
--- a/lib/brcobranca/boleto/base.rb
+++ b/lib/brcobranca/boleto/base.rb
@@ -91,6 +91,8 @@ module Brcobranca
       attr_accessor :cedente_endereco
       # <b>OPCIONAL</b>: EMV para gerar QRCode para pagamento via PIX
       attr_accessor :emv
+      # <b>OPCIONAL</b>: Descontos e abatimentos
+      attr_accessor :descontos_e_abatimentos
 
       # Validações
       validates_presence_of :agencia, :conta_corrente, :moeda, :especie_documento, :especie, :aceite, :nosso_numero,

--- a/lib/brcobranca/boleto/template/rghost_bolepix.rb
+++ b/lib/brcobranca/boleto/template/rghost_bolepix.rb
@@ -237,6 +237,10 @@ module Brcobranca
           move_more(doc, 10.1, 0)
           doc.show boleto.valor_documento.to_currency
 
+          move_more(doc, 0, -0.8)
+          doc.show boleto.descontos_e_abatimentos.to_currency
+
+          move_more(doc, 0, 0.8)
           if boleto.instrucoes
             doc.text_area boleto.instrucoes, width: '14 cm',
                                              text_align: :left, x: "#{@x -= 15.8} cm",

--- a/lib/brcobranca/boleto/template/rghost_bolepix.rb
+++ b/lib/brcobranca/boleto/template/rghost_bolepix.rb
@@ -156,7 +156,7 @@ module Brcobranca
           doc.show boleto.valor_documento.to_currency
 
           move_more(doc, -15.8, -0.75)
-          doc.show boleto.descontos_e_abatimentos.to_currency
+          doc.show boleto.descontos_e_abatimentos&.to_currency
 
           move_more(doc, 0.8, -0.55)
           doc.show "#{boleto.sacado} - #{boleto.sacado_documento.formata_documento}"
@@ -238,7 +238,7 @@ module Brcobranca
           doc.show boleto.valor_documento.to_currency
 
           move_more(doc, 0, -0.8)
-          doc.show boleto.descontos_e_abatimentos.to_currency
+          doc.show boleto.descontos_e_abatimentos&.to_currency
 
           move_more(doc, 0, 0.8)
           if boleto.instrucoes

--- a/lib/brcobranca/boleto/template/rghost_bolepix.rb
+++ b/lib/brcobranca/boleto/template/rghost_bolepix.rb
@@ -158,7 +158,7 @@ module Brcobranca
           move_more(doc, -15.8, -0.75)
           doc.show boleto.descontos_e_abatimentos.to_currency
 
-          move_more(doc, 7, -0.55)
+          move_more(doc, 0.8, -0.55)
           doc.show "#{boleto.sacado} - #{boleto.sacado_documento.formata_documento}"
 
           move_more(doc, 0, -0.3)

--- a/lib/brcobranca/boleto/template/rghost_bolepix.rb
+++ b/lib/brcobranca/boleto/template/rghost_bolepix.rb
@@ -155,7 +155,10 @@ module Brcobranca
           move_more(doc, 5, 0)
           doc.show boleto.valor_documento.to_currency
 
-          move_more(doc, -15, -1.3)
+          move_more(doc, -15.8, -0.75)
+          doc.show boleto.descontos_e_abatimentos.to_currency
+
+          move_more(doc, 7, -0.55)
           doc.show "#{boleto.sacado} - #{boleto.sacado_documento.formata_documento}"
 
           move_more(doc, 0, -0.3)


### PR DESCRIPTION
Adiciona a possibilidade de preencher abatimentos e descontos nos campos devidos do template genérico.

Foi alterado apenas em `Brcobranca::Boleto::Template::RghostBolepix` por ser o que nós usamos aqui e ser o template que contribuímos da outra vez.

![image](https://github.com/user-attachments/assets/f41e3981-d92a-4c81-b966-5ddc96ca3158)
