### PR TITLE
Cnab444 itau

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Criado pelo pessoal da [Akretion](http://www.akretion.com) muito TOP \o/
 | Caixa             | 240             | 240                   |
 | Citibank          | Não             | 400                   |
 | HSBC              | Não             | Não                   |
-| Itaú              | 400             | 400                   |
+| Itaú              | 400             | 400 e 444             |
 | Santander         | 400 e 240       | 400 e 240             |
 | Sicoob            | 240             | 400 e 240             |
 | Sicredi           | 240             | 240                   |
@@ -65,6 +65,7 @@ Criado pelo pessoal da [Akretion](http://www.akretion.com) muito TOP \o/
 - Caixa Economica Federal (CNAB240) [Isabella](https://github.com/isabellaSantos) da [Zaez](http://www.zaez.net)
 - Bradesco (CNAB400) [Isabella](https://github.com/isabellaSantos) da [Zaez](http://www.zaez.net)
 - Itaú (CNAB400) [Isabella](https://github.com/isabellaSantos) da [Zaez](http://www.zaez.net)
+- Itaú (CNAB444) [Junior Tada](https://github.com/juniortada) 
 - Citibank (CNAB400)
 - Santander (CNAB400)
 - Santander (CNAB240)

--- a/lib/brcobranca.rb
+++ b/lib/brcobranca.rb
@@ -176,6 +176,10 @@ module Brcobranca
       autoload :Credisis,      'brcobranca/remessa/cnab400/credisis'
     end
 
+    module Cnab444
+      autoload :Itau,          'brcobranca/remessa/cnab444/itau'
+    end
+
     module Cnab240
       autoload :Base,               'brcobranca/remessa/cnab240/base'
       autoload :BaseCorrespondente, 'brcobranca/remessa/cnab240/base_correspondente'

--- a/lib/brcobranca/remessa/cnab444/itau.rb
+++ b/lib/brcobranca/remessa/cnab444/itau.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Brcobranca
+  module Remessa
+    module Cnab444
+      class Itau < Brcobranca::Remessa::Cnab400::Itau
+
+        # Detalhe do arquivo
+        #
+        # @param pagamento [PagamentoCnab444]
+        #   objeto contendo as informacoes referentes ao boleto (valor, vencimento, cliente)
+        # @param sequencial
+        #   num. sequencial do registro no arquivo
+        #
+        # @return [String]
+        #
+        def monta_detalhe(pagamento, sequencial)
+          detalhe = super(pagamento, sequencial)
+  
+          detalhe + pagamento.chave_nfe.to_s.ljust(44, ' ')                 # chave da nota fiscal (NFe)            X[44]
+        end
+      end
+    end
+  end
+end

--- a/lib/brcobranca/remessa/pagamento.rb
+++ b/lib/brcobranca/remessa/pagamento.rb
@@ -89,6 +89,8 @@ module Brcobranca
       attr_accessor :dias_baixa
       # <b>OPCIONAL</b>: Número da Parcela
       attr_accessor :parcela
+      # <b>OPCIONAL</b>: Chave da Nota Fiscal Eletrônica
+      attr_accessor :chave_nfe
 
       validates_presence_of :nosso_numero, :data_vencimento, :valor,
                             :documento_sacado, :nome_sacado, :endereco_sacado,

--- a/spec/brcobranca/remessa/cnab444/itau_spec.rb
+++ b/spec/brcobranca/remessa/cnab444/itau_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Brcobranca::Remessa::Cnab444::Itau do
+  let(:chave_nfe) { '12345678901234567890123456789012345678901234' }
+  let(:pagamento) do
+    Brcobranca::Remessa::Pagamento.new(valor: 199.9,
+                                       data_vencimento: Date.current,
+                                       nosso_numero: 123,
+                                       documento: 6969,
+                                       documento_sacado: '12345678901',
+                                       nome_sacado: 'PABLO DIEGO JOSÉ FRANCISCO,!^.?\/@  DE PAULA JUAN NEPOMUCENO MARÍA DE LOS REMEDIOS CIPRIANO DE LA SANTÍSSIMA TRINIDAD RUIZ Y PICASSO',
+                                       endereco_sacado: 'RUA RIO GRANDE DO SUL,!^.?\/@ São paulo Minas caçapa da silva junior',
+                                       bairro_sacado: 'São josé dos quatro apostolos magros',
+                                       cep_sacado: '12345678',
+                                       cidade_sacado: 'Santa rita de cássia maria da silva',
+                                       codigo_multa: '1',
+                                       percentual_multa: 2.00,
+                                       uf_sacado: 'SP',
+                                       chave_nfe: chave_nfe)
+  end
+  let(:params) do
+    { carteira: '123',
+      agencia: '1234',
+      conta_corrente: '12345',
+      digito_conta: '1',
+      empresa_mae: 'SOCIEDADE BRASILEIRA DE ZOOLOGIA LTDA',
+      documento_cedente: '12345678910',
+      pagamentos: [pagamento] }
+  end
+  let(:itau) { subject.class.new(params) }
+
+  context 'monta remessa' do
+    context 'detalhe' do
+        it 'informacoes devem estar posicionadas corretamente no detalhe' do
+            detalhe = itau.monta_detalhe pagamento, 2
+            expect(detalhe[37..61]).to eq '6969'.ljust(25)
+            expect(detalhe[62..69]).to eq '00000123' # nosso numero
+            expect(detalhe[120..125]).to eq Date.current.strftime('%d%m%y') # data de vencimento
+            expect(detalhe[126..138]).to eq '0000000019990' # valor do titulo
+            expect(detalhe[142..146]).to eq '00000' # agência cobradora
+            expect(detalhe[156..157]).to eq '00' # instrução 1
+            expect(detalhe[158..159]).to eq '00' # instrução 2
+            expect(detalhe[220..233]).to eq '00012345678901' # documento do pagador
+            expect(detalhe[234..263]).to eq 'PABLO DIEGO JOSE FRANCISCO DE ' # nome do pagador
+            expect(detalhe[400..443]).to eq chave_nfe                        # Chave da Nota Fiscal               [401..444]  x(044)
+        end
+
+        it 'informacoes devem estar posicionadas corretamente no detalhe opcional de multa' do
+            detalhe_multa = itau.monta_detalhe_multa pagamento, 3
+            # Significado                        Posição     Picture
+            expect(detalhe_multa[0]).to eq '2'                                # Identificação do reg. transação    [001..001]  9(001)
+            expect(detalhe_multa[1]).to eq '1'                                # Código da multa                    [002..002]  X(001)
+            expect(detalhe_multa[2..9]).to eq Date.current.strftime('%d%m%Y') # Data da multa                      [003..010]  9(008)
+            expect(detalhe_multa[10..22]).to eq '0000000000200'               # Valor da multa                     [011..023]  9(013)
+            expect(detalhe_multa[23..393]).to eq ''.rjust(371, ' ')           # Complemento                        [024..394]  X(370)
+            expect(detalhe_multa[394..399]).to eq '000003'                    # Número sequencial                  [395..400]  9(006)
+        end
+      end
+  
+      context 'arquivo' do
+        before { Timecop.freeze(Time.local(2015, 7, 14, 16, 15, 15)) }
+  
+        after { Timecop.return }
+  
+        it { expect(itau.gera_arquivo).to eq(read_remessa('remessa-itau-cnab444.rem', itau.gera_arquivo)) }
+      end
+  end
+end


### PR DESCRIPTION
O CNAB 444 é amplamente utilizado pelas principais administradoras de fundo no Brasil, FIDC's e sistemas especiais que vinculam a chave NFe/XML nas últimas 44 posições do CNAB400 tornando-o CNAB444.

Essa alteração adiciona a geração do CNAB 444 para o banco Itaú.

## Resumo por Sourcery

Adiciona suporte ao CNAB 444 para o banco Itaú, que é usado por gestores de fundos no Brasil para vincular chaves NFe/XML nas últimas 44 posições do CNAB400.

Novas funcionalidades:
- Adiciona geração de CNAB 444 para o banco Itaú.
- Adiciona o atributo `chave_nfe` (chave NFe) à classe `Pagamento`.

Testes:
- Adiciona testes para `CNAB444::Itau`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adds support for CNAB 444 for Itaú bank, which is used by fund managers in Brazil to link NFe/XML keys in the last 44 positions of the CNAB400.

New Features:
- Adds CNAB 444 generation for Itaú bank.
- Adds the chave_nfe (NFe key) attribute to the Pagamento class.

Tests:
- Adds tests for CNAB444::Itau.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Atualizada a documentação de Itaú, que agora informa suporte para os formatos CNAB400 e CNAB444.

- **New Features**
  - Expandido o processamento de remessas para Itaú com a inclusão do novo formato CNAB444.
  - Adicionada a opção de integrar a chave da Nota Fiscal Eletrônica nos registros de pagamento.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->