### PR TITLE
Remove metadata duplicado do gemspec

### DIFF
--- a/brcobranca.gemspec
+++ b/brcobranca.gemspec
@@ -31,8 +31,4 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'parseline', '>= 1.0.3'
   gem.add_dependency 'rghost', '= 0.9.8'
   gem.add_dependency 'rghost_barcode', '>= 0.9'
-
-  gem.metadata = {
-    'rubygems_mfa_required' => 'true'
-  }
 end


### PR DESCRIPTION
### Descrição
Este PR remove a declaração duplicada de `gem.metadata` no arquivo brcobranca.gemspec.

### Problema
O arquivo gemspec estava declarando `gem.metadata` duas vezes:
1. Uma declaração completa (linhas 19-26) com todas as configurações de metadata
2. Uma declaração duplicada no final do arquivo apenas com `rubygems_mfa_required`

Isso fazia com que a segunda declaração sobrescrevesse a primeira, causando a perda dos dados.

### Solução
Removida a declaração duplicada de metadata no final do arquivo, mantendo apenas a declaração completa que já continha todas as configurações necessárias, incluindo:
- `homepage_uri`
- `changelog_uri`
- `source_code_uri`
- `bug_tracker_uri`
- `documentation_uri`
- `rubygems_mfa_required`

## Summary by Sourcery

Correções de bugs:
- Corrige a perda de metadados da gem causada por uma segunda atribuição de metadados que sobrescreve toda a configuração no arquivo gemspec.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix loss of gem metadata caused by a second metadata assignment overwriting the complete configuration in the gemspec.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **Chores**
  * Removida uma entrada duplicada de configuração do arquivo de especificação da gema, mantendo a integridade das demais configurações.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->