### PR TITLE
Remove parseline gem

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,3 +18,18 @@ Layout/LineLength:
 
 Style/SuperArguments:
   Enabled: false
+
+RSpec/ContextWording:
+  Enabled: true
+  Prefixes:
+    - quando
+    - com
+    - sem
+
+RSpec/MultipleExpectations:
+  Enabled: true
+  Max: 10
+
+RSpec/ExampleLength:
+  Enabled: true
+  Max: 25

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 require:
   - rubocop-performance
-  - 'test_prof/rubocop'
+  - "test_prof/rubocop"
   - rubocop-rspec
   - rubocop-packaging
 
@@ -15,3 +15,6 @@ Style/FrozenStringLiteralComment:
 Layout/LineLength:
   Max: 125
   AllowedPatterns: ['\A#']
+
+Style/SuperArguments:
+  Enabled: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     brcobranca (13.0.0)
       fast_blank
-      parseline (>= 1.0.3)
       rghost (= 0.9.8)
       rghost_barcode (>= 0.9)
 
@@ -23,7 +22,6 @@ GEM
     logger (1.7.0)
     method_source (1.1.0)
     parallel (2.1.0)
-    parseline (1.0.3)
     parser (3.3.12.0)
       ast (~> 2.4.1)
       racc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     brcobranca (12.0.0)
       fast_blank
-      parseline (>= 1.0.3)
       rghost (= 0.9.8)
       rghost_barcode (>= 0.9)
 
@@ -22,7 +21,6 @@ GEM
     lint_roller (1.1.0)
     method_source (1.1.0)
     parallel (1.27.0)
-    parseline (1.0.3)
     parser (3.3.8.0)
       ast (~> 2.4.1)
       racc

--- a/brcobranca.gemspec
+++ b/brcobranca.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |gem|
   gem.requirements = ['GhostScript > 9.0, para gerar PDF e código de Barras']
 
   gem.add_dependency 'fast_blank'
-  gem.add_dependency 'parseline', '>= 1.0.3'
   gem.add_dependency 'rghost', '= 0.9.8'
   gem.add_dependency 'rghost_barcode', '>= 0.9'
 

--- a/lib/brcobranca.rb
+++ b/lib/brcobranca.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'fast_blank'
 require 'brcobranca/calculo'
 require 'brcobranca/limpeza'
 require 'brcobranca/formatacao'
@@ -7,8 +8,8 @@ require 'brcobranca/formatacao_string'
 require 'brcobranca/calculo_data'
 require 'brcobranca/currency'
 require 'brcobranca/validations'
+require 'brcobranca/parse_line'
 require 'brcobranca/util/date'
-require 'fast_blank'
 
 module Brcobranca
   # Exception lançada quando algum tipo de boleto soicitado ainda não tiver sido implementado.
@@ -16,6 +17,9 @@ module Brcobranca
   end
 
   class ValorInvalido < StandardError
+  end
+
+  class MalformedLayoutOrLine < StandardError
   end
 
   # Exception lançada quando os dados informados para o boleto estão inválidos.

--- a/lib/brcobranca/parse_line.rb
+++ b/lib/brcobranca/parse_line.rb
@@ -6,110 +6,112 @@ module Brcobranca
   #
   # Originalmente baseado em: https://github.com/shairontoledo/parseline
   module ParseLine
-    module_eval do # rubocop:disable Metrics/BlockLength
-      # Define o layout de cada linha do arquivo de acordo com as posicoes de cada campo.
-      # Exemplo:
-      #     class BancoX < Base
-      #       extend ParseLine
-      #
-      #       fixed_width_layout do |layout|
-      #         layout.field :campo1, 0...10
-      #         layout.field :campo2, 10...20 do |value|
-      #           value.to_i
-      #         end
-      #       end
-      #     end
-      def fixed_width_layout
-        yield self if block_given?
+    # :nodoc:
+    def parse_values
+      @parse_values ||= []
+    end
+
+    # Define o layout de cada linha do arquivo de acordo com as posicoes de cada campo.
+    # Exemplo:
+    #     class BancoX < Base
+    #       extend ParseLine
+    #
+    #       fixed_width_layout do |layout|
+    #         layout.field :campo1, 0...10
+    #         layout.field :campo2, 10...20 do |value|
+    #           value.to_i
+    #         end
+    #       end
+    #     end
+    def fixed_width_layout
+      yield self if block_given?
+    end
+
+    # Define um campo do layout, indicando o nome do campo,
+    # a posicao (range) e opcionalmente um bloco para processar o valor do campo.
+    # Exemplo:
+    #     layout.field :campo1, 0...10
+    #     layout.field :campo2, 10...20 do |value|
+    #       value.to_i
+    #     end
+    #
+    # @param [Symbol] field O nome do campo a ser definido.
+    # @param [Range] range O intervalo de caracteres onde o campo esta localizado na linha do arquivo.
+    # @param [Proc] proc (opcional) Um bloco para processar o valor do campo antes de atribui-lo ao objeto.
+    def field(field, range, proc = nil)
+      parse_values << [field, range, proc]
+    end
+
+    # Le as linhas de um arquivo e retorna um array de objetos com os campos preenchidos de acordo com o layout definido.
+    # Opcoes:
+    # - :except => [1, 3] (ignora as linhas 1 e 3)
+    # - :except => /regex/ (ignora as linhas que correspondem ao regex)
+    # - :length => 100 (considera apenas as linhas com tamanho igual a 100 caracteres)
+    #
+    # @param [String] filepath O caminho do arquivo a ser lido.
+    # @param [Hash] options Opcoes para filtrar as linhas a serem processadas.
+    def load_lines(filepath, options = {})
+      if options[:except].is_a?(Array)
+        return load_lines_except_array(filepath, options[:except], options[:length])
+      elsif options[:except].is_a?(Regexp)
+        return load_lines_except_regex(filepath, options[:except], options[:length])
       end
 
-      # Define um campo do layout, indicando o nome do campo,
-      # a posicao (range) e opcionalmente um bloco para processar o valor do campo.
-      # Exemplo:
-      #     layout.field :campo1, 0...10
-      #     layout.field :campo2, 10...20 do |value|
-      #       value.to_i
-      #     end
-      #
-      # @param [Symbol] field O nome do campo a ser definido.
-      # @param [Range] range O intervalo de caracteres onde o campo esta localizado na linha do arquivo.
-      # @param [Proc] proc (opcional) Um bloco para processar o valor do campo antes de atribui-lo ao objeto.
-      def field(field, range, proc = nil)
-        send(:class_variable_set, :@@parse_values, []) unless class_variable_defined?(:@@parse_values)
-        send(:class_variable_get, :@@parse_values) << [field, range, proc]
+      File.open(filepath).each_with_object([]) do |line, lines|
+        next unless line_length_valid?(line, options[:length])
+
+        lines << load_line(line)
+      end
+    end
+
+    def load_lines_except_array(filepath, except, length = nil)
+      lines = []
+
+      File.open(filepath).each_with_index do |line, i|
+        next if line.blank? || except.include?(i + 1)
+        next unless line_length_valid?(line, length)
+
+        lines << load_line(line)
       end
 
-      # Le as linhas de um arquivo e retorna um array de objetos com os campos preenchidos de acordo com o layout definido.
-      # Opcoes:
-      # - :except => [1, 3] (ignora as linhas 1 e 3)
-      # - :except => /regex/ (ignora as linhas que correspondem ao regex)
-      # - :length => 100 (considera apenas as linhas com tamanho igual a 100 caracteres)
-      #
-      # @param [String] filepath O caminho do arquivo a ser lido.
-      # @param [Hash] options Opcoes para filtrar as linhas a serem processadas.
-      def load_lines(filepath, options = {})
-        if options[:except].is_a?(Array)
-          return load_lines_except_array(filepath, options[:except], options[:length])
-        elsif options[:except].is_a?(Regexp)
-          return load_lines_except_regex(filepath, options[:except], options[:length])
-        end
+      lines
+    end
 
-        File.open(filepath).each_with_object([]) do |line, lines|
-          next unless line_length_valid?(line, options[:length])
+    def load_lines_except_regex(filepath, except, length = nil)
+      lines = []
 
-          lines << load_line(line)
-        end
+      File.open(filepath).each do |line|
+        next if line.blank? || except.match?(line)
+        next unless line_length_valid?(line, length)
+
+        lines << load_line(line)
       end
 
-      def load_lines_except_array(filepath, except, length = nil)
-        lines = []
+      lines
+    end
 
-        File.open(filepath).each_with_index do |line, i|
-          next if line.blank? || except.include?(i + 1)
-          next unless line_length_valid?(line, length)
+    # Processa uma linha do arquivo de acordo com o layout definido e retorna um objeto com os campos preenchidos.
+    # Se a linha nao corresponder ao layout definido, uma excecao e levantada.
+    # @param [String] line A linha do arquivo a ser processada.
+    # @return [Object] Um objeto com os campos preenchidos de acordo com o layout definido.
+    def load_line(line)
+      instance = new
 
-          lines << load_line(line)
-        end
-
-        lines
+      parse_values.each do |field_name, range, transformer|
+        value = transformer ? transformer.call(line[range]) : line[range].to_s.strip
+        instance.public_send("#{field_name}=", value)
       end
 
-      def load_lines_except_regex(filepath, except, length = nil)
-        lines = []
+      instance
+    rescue StandardError => e
+      raise Brcobranca::MalformedLayoutOrLine, "Linha malformada ou layout incorreto: '#{line}', tamanho: #{line.size} " \
+                                               "Erro original: (#{e.class}): #{e.message}"
+    end
 
-        File.open(filepath).each do |line|
-          next if line.blank? || except.match?(line)
-          next unless line_length_valid?(line, length)
+    def line_length_valid?(line, expected_length = nil)
+      return true if expected_length.nil?
 
-          lines << load_line(line)
-        end
-
-        lines
-      end
-
-      # Processa uma linha do arquivo de acordo com o layout definido e retorna um objeto com os campos preenchidos.
-      # Se a linha nao corresponder ao layout definido, uma excecao e levantada.
-      # @param [String] line A linha do arquivo a ser processada.
-      # @return [Object] Um objeto com os campos preenchidos de acordo com o layout definido.
-      def load_line(line)
-        instance = new
-
-        class_variable_get(:@@parse_values).each do |field_name, range, transformer|
-          value = transformer ? transformer.call(line[range]) : line[range].to_s.strip
-          instance.public_send("#{field_name}=", value)
-        end
-
-        instance
-      rescue StandardError => e
-        raise MalformedLayoutOrLine, "Linha malformada ou layout incorreto: '#{line}', tamanho: #{line.size}" \
-                                     "Erro original: (#{e.class}): #{e.message}"
-      end
-
-      def line_length_valid?(line, expected_length = nil)
-        return true if expected_length.nil?
-
-        line.to_s.strip.length == expected_length.to_i
-      end
+      line.to_s.strip.length == expected_length.to_i
     end
   end
 end

--- a/lib/brcobranca/parse_line.rb
+++ b/lib/brcobranca/parse_line.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+module Brcobranca
+  # Modulo para parsear linhas de arquivos de retorno e remessa.
+  # Ele e utilizado para definir o layout de cada banco e depois ler as linhas do arquivo de acordo com esse layout.
+  #
+  # Originalmente baseado em: https://github.com/shairontoledo/parseline
+  module ParseLine
+    module_eval do # rubocop:disable Metrics/BlockLength
+      # Define o layout de cada linha do arquivo de acordo com as posicoes de cada campo.
+      # Exemplo:
+      #     class BancoX < Base
+      #       extend ParseLine
+      #
+      #       fixed_width_layout do |layout|
+      #         layout.field :campo1, 0...10
+      #         layout.field :campo2, 10...20 do |value|
+      #           value.to_i
+      #         end
+      #       end
+      #     end
+      def fixed_width_layout
+        yield self if block_given?
+      end
+
+      # Define um campo do layout, indicando o nome do campo,
+      # a posicao (range) e opcionalmente um bloco para processar o valor do campo.
+      # Exemplo:
+      #     layout.field :campo1, 0...10
+      #     layout.field :campo2, 10...20 do |value|
+      #       value.to_i
+      #     end
+      #
+      # @param [Symbol] field O nome do campo a ser definido.
+      # @param [Range] range O intervalo de caracteres onde o campo esta localizado na linha do arquivo.
+      # @param [Proc] proc (opcional) Um bloco para processar o valor do campo antes de atribui-lo ao objeto.
+      def field(field, range, proc = nil)
+        send(:class_variable_set, :@@parse_values, []) unless class_variable_defined?(:@@parse_values)
+        send(:class_variable_get, :@@parse_values) << [field, range, proc]
+      end
+
+      # Le as linhas de um arquivo e retorna um array de objetos com os campos preenchidos de acordo com o layout definido.
+      # Opcoes:
+      # - :except => [1, 3] (ignora as linhas 1 e 3)
+      # - :except => /regex/ (ignora as linhas que correspondem ao regex)
+      # - :length => 100 (considera apenas as linhas com tamanho igual a 100 caracteres)
+      #
+      # @param [String] filepath O caminho do arquivo a ser lido.
+      # @param [Hash] options Opcoes para filtrar as linhas a serem processadas.
+      def load_lines(filepath, options = {})
+        if options[:except].is_a?(Array)
+          return load_lines_except_array(filepath, options[:except], options[:length])
+        elsif options[:except].is_a?(Regexp)
+          return load_lines_except_regex(filepath, options[:except], options[:length])
+        end
+
+        File.open(filepath).each_with_object([]) do |line, lines|
+          next unless line_length_valid?(line, options[:length])
+
+          lines << load_line(line)
+        end
+      end
+
+      def load_lines_except_array(filepath, except, length = nil)
+        lines = []
+
+        File.open(filepath).each_with_index do |line, i|
+          next if line.blank? || except.include?(i + 1)
+          next unless line_length_valid?(line, length)
+
+          lines << load_line(line)
+        end
+
+        lines
+      end
+
+      def load_lines_except_regex(filepath, except, length = nil)
+        lines = []
+
+        File.open(filepath).each do |line|
+          next if line.blank? || except.match?(line)
+          next unless line_length_valid?(line, length)
+
+          lines << load_line(line)
+        end
+
+        lines
+      end
+
+      # Processa uma linha do arquivo de acordo com o layout definido e retorna um objeto com os campos preenchidos.
+      # Se a linha nao corresponder ao layout definido, uma excecao e levantada.
+      # @param [String] line A linha do arquivo a ser processada.
+      # @return [Object] Um objeto com os campos preenchidos de acordo com o layout definido.
+      def load_line(line)
+        instance = new
+
+        class_variable_get(:@@parse_values).each do |field_name, range, transformer|
+          value = transformer ? transformer.call(line[range]) : line[range].to_s.strip
+          instance.public_send("#{field_name}=", value)
+        end
+
+        instance
+      rescue StandardError => e
+        raise MalformedLayoutOrLine, "Linha malformada ou layout incorreto: '#{line}', tamanho: #{line.size}" \
+                                     "Erro original: (#{e.class}): #{e.message}"
+      end
+
+      def line_length_valid?(line, expected_length = nil)
+        return true if expected_length.nil?
+
+        line.to_s.strip.length == expected_length.to_i
+      end
+    end
+  end
+end

--- a/lib/brcobranca/parse_line.rb
+++ b/lib/brcobranca/parse_line.rb
@@ -6,9 +6,16 @@ module Brcobranca
   #
   # Originalmente baseado em: https://github.com/shairontoledo/parseline
   module ParseLine
-    # :nodoc:
+    # Campos definidos para a classe.
+    #
+    # Uma subclasse comeca com uma copia dos campos da classe pai e a partir
+    # dai tem vida propria: definir um campo na filha nunca altera o layout da
+    # mae. E o que permite ao Retorno::Cnab240::Caixa reaproveitar o layout
+    # generico do CNAB 240 sobrescrevendo apenas alguns campos.
+    #
+    # @return [Array<Array>] lista de [campo, range, transformador].
     def parse_values
-      @parse_values ||= []
+      @parse_values ||= parse_values_herdados
     end
 
     # Define o layout de cada linha do arquivo de acordo com as posicoes de cada campo.
@@ -38,8 +45,8 @@ module Brcobranca
     # @param [Symbol] field O nome do campo a ser definido.
     # @param [Range] range O intervalo de caracteres onde o campo esta localizado na linha do arquivo.
     # @param [Proc] proc (opcional) Um bloco para processar o valor do campo antes de atribui-lo ao objeto.
-    def field(field, range, proc = nil)
-      parse_values << [field, range, proc]
+    def field(field, range, proc = nil, &block)
+      parse_values << [field, range, proc || block]
     end
 
     # Le as linhas de um arquivo e retorna um array de objetos com os campos preenchidos de acordo com o layout definido.
@@ -57,21 +64,23 @@ module Brcobranca
         return load_lines_except_regex(filepath, options[:except], options[:length])
       end
 
-      File.open(filepath).each_with_object([]) do |line, lines|
-        next unless line_length_valid?(line, options[:length])
-
-        lines << load_line(line)
+      File.open(filepath) do |file|
+        file.each_with_object([]) do |line, lines|
+          lines << load_line(line) if line_valid?(line, options[:length])
+        end
       end
     end
 
     def load_lines_except_array(filepath, except, length = nil)
       lines = []
 
-      File.open(filepath).each_with_index do |line, i|
-        next if line.blank? || except.include?(i + 1)
-        next unless line_length_valid?(line, length)
+      File.open(filepath) do |file|
+        file.each_with_index do |line, i|
+          next if except.include?(i + 1)
+          next unless line_valid?(line, length)
 
-        lines << load_line(line)
+          lines << load_line(line)
+        end
       end
 
       lines
@@ -80,11 +89,13 @@ module Brcobranca
     def load_lines_except_regex(filepath, except, length = nil)
       lines = []
 
-      File.open(filepath).each do |line|
-        next if line.blank? || except.match?(line)
-        next unless line_length_valid?(line, length)
+      File.open(filepath) do |file|
+        file.each do |line|
+          next if except.match?(line)
+          next unless line_valid?(line, length)
 
-        lines << load_line(line)
+          lines << load_line(line)
+        end
       end
 
       lines
@@ -108,10 +119,29 @@ module Brcobranca
                                                "Erro original: (#{e.class}): #{e.message}"
     end
 
+    # Linha em branco nunca vira registro, com ou sem filtro.
+    def line_valid?(line, expected_length = nil)
+      !line.blank? && line_length_valid?(line, expected_length)
+    end
+
+    # Compara o tamanho da linha sem a quebra de linha (\n ou \r\n).
+    #
+    # Nao usar strip aqui: registros CNAB sao preenchidos com brancos a
+    # direita e seriam descartados por engano.
     def line_length_valid?(line, expected_length = nil)
       return true if expected_length.nil?
 
-      line.to_s.strip.length == expected_length.to_i
+      line.to_s.chomp.length == expected_length.to_i
+    end
+
+    private
+
+    # Copia dos campos da classe pai, quando ela tambem usa o ParseLine.
+    def parse_values_herdados
+      return [] unless is_a?(Class)
+
+      pai = superclass
+      pai.respond_to?(:parse_values) ? pai.parse_values.dup : []
     end
   end
 end

--- a/lib/brcobranca/retorno/cnab240/ailos.rb
+++ b/lib/brcobranca/retorno/cnab240/ailos.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'parseline'
-
 module Brcobranca
   module Retorno
     module Cnab240
@@ -39,7 +37,7 @@ module Brcobranca
         # O primeiro é do tipo T que retorna dados gerais sobre a transação
         # O segundo é do tipo U que retorna os valores da transação
         class Line < Base
-          extend ParseLine::FixedWidth # Extendendo parseline
+          extend ParseLine
 
           REGISTRO_T_FIELDS = %w[codigo_registro codigo_ocorrencia agencia_com_dv cedente_com_dv nosso_numero carteira
                                  data_vencimento valor_titulo banco_recebedor agencia_recebedora_com_dv sequencial valor_tarifa motivo_ocorrencia].freeze

--- a/lib/brcobranca/retorno/cnab240/base.rb
+++ b/lib/brcobranca/retorno/cnab240/base.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "parseline"
-
 module Brcobranca
   module Retorno
     module Cnab240

--- a/lib/brcobranca/retorno/cnab240/base.rb
+++ b/lib/brcobranca/retorno/cnab240/base.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'parseline'
-
 module Brcobranca
   module Retorno
     module Cnab240

--- a/lib/brcobranca/retorno/cnab240/itau.rb
+++ b/lib/brcobranca/retorno/cnab240/itau.rb
@@ -75,7 +75,7 @@ module Brcobranca
         # Posicoes conforme manual "Cobranca FEBRABAN 240" do Itau, item
         # 3.2 (Arquivo Retorno), Segmentos T e U.
         class Line < Base
-          extend ParseLine::FixedWidth # Extendendo parseline
+          extend ParseLine
 
           REGISTRO_T_FIELDS = %w[
             codigo_registro codigo_ocorrencia agencia_com_dv carteira

--- a/lib/brcobranca/retorno/cnab240/santander.rb
+++ b/lib/brcobranca/retorno/cnab240/santander.rb
@@ -37,7 +37,7 @@ module Brcobranca
         # O primeiro é do tipo T que retorna dados gerais sobre a transação
         # O segundo é do tipo U que retorna os valores da transação
         class Line < Base
-          extend ParseLine::FixedWidth # Extendendo parseline
+          extend ParseLine
 
           REGISTRO_T_FIELDS = %w[codigo_registro codigo_ocorrencia agencia_com_dv cedente_com_dv nosso_numero carteira
                                  data_vencimento valor_titulo banco_recebedor agencia_recebedora_com_dv sequencial valor_tarifa motivo_ocorrencia].freeze

--- a/lib/brcobranca/retorno/cnab240/sicoob.rb
+++ b/lib/brcobranca/retorno/cnab240/sicoob.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'parseline'
-
 module Brcobranca
   module Retorno
     module Cnab240
@@ -39,7 +37,7 @@ module Brcobranca
         # O primeiro é do tipo T que retorna dados gerais sobre a transação
         # O segundo é do tipo U que retorna os valores da transação
         class Line < Base
-          extend ParseLine::FixedWidth # Extendendo parseline
+          extend ParseLine
 
           REGISTRO_T_FIELDS = %w[codigo_registro codigo_ocorrencia agencia_com_dv cedente_com_dv nosso_numero carteira
                                  data_vencimento valor_titulo banco_recebedor agencia_recebedora_com_dv sequencial valor_tarifa motivo_ocorrencia].freeze

--- a/lib/brcobranca/retorno/cnab240/sicredi.rb
+++ b/lib/brcobranca/retorno/cnab240/sicredi.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'parseline'
-
 module Brcobranca
   module Retorno
     module Cnab240
@@ -39,7 +37,7 @@ module Brcobranca
         # O primeiro é do tipo T que retorna dados gerais sobre a transação
         # O segundo é do tipo U que retorna os valores da transação
         class Line < Base
-          extend ParseLine::FixedWidth # Extendendo parseline
+          extend ParseLine
 
           REGISTRO_T_FIELDS = %w[codigo_registro codigo_ocorrencia agencia_com_dv cedente_com_dv nosso_numero carteira
                                  data_vencimento valor_titulo banco_recebedor agencia_recebedora_com_dv sequencial valor_tarifa motivo_ocorrencia].freeze

--- a/lib/brcobranca/retorno/cnab400/banco_brasil.rb
+++ b/lib/brcobranca/retorno/cnab400/banco_brasil.rb
@@ -1,14 +1,12 @@
 # frozen_string_literal: true
 
-require 'parseline'
-
 module Brcobranca
   module Retorno
     module Cnab400
       # Formato de Retorno CNAB 400
       # Baseado em: http://www.bb.com.br/docs/pub/emp/empl/dwn/Doc2628CBR643Pos7.pdf
       class BancoBrasil < Brcobranca::Retorno::Cnab400::Base
-        extend ParseLine::FixedWidth # Extendendo parseline
+        extend ParseLine
 
         # Load lines
         def self.load_lines(file, options = {})

--- a/lib/brcobranca/retorno/cnab400/banco_brasilia.rb
+++ b/lib/brcobranca/retorno/cnab400/banco_brasilia.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
-require 'parseline'
-
 module Brcobranca
   module Retorno
     module Cnab400
       # Formato de Retorno CNAB 400
       class BancoBrasilia < Brcobranca::Retorno::Base
-        extend ParseLine::FixedWidth
+        extend ParseLine
 
         def self.load_lines(file, options = {})
           default_options = { except: [1] } # por padrao ignora a primeira linha que é header

--- a/lib/brcobranca/retorno/cnab400/banco_nordeste.rb
+++ b/lib/brcobranca/retorno/cnab400/banco_nordeste.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
-require 'parseline'
-
 module Brcobranca
   module Retorno
     module Cnab400
       # Formato de Retorno CNAB 400
       class BancoNordeste < Brcobranca::Retorno::Base
-        extend ParseLine::FixedWidth
+        extend ParseLine
 
         def self.load_lines(file, options = {})
           default_options = { except: [1] } # por padrao ignora a primeira linha que é header

--- a/lib/brcobranca/retorno/cnab400/banrisul.rb
+++ b/lib/brcobranca/retorno/cnab400/banrisul.rb
@@ -4,7 +4,7 @@ module Brcobranca
   module Retorno
     module Cnab400
       class Banrisul < Brcobranca::Retorno::Cnab400::Base
-        extend ParseLine::FixedWidth # Extendendo parseline
+        extend ParseLine
 
         def self.load_lines(file, options = {})
           default_options = { except: [1] } # por padrao ignora a primeira linha que é header

--- a/lib/brcobranca/retorno/cnab400/base.rb
+++ b/lib/brcobranca/retorno/cnab400/base.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'parseline'
-
 module Brcobranca
   module Retorno
     module Cnab400

--- a/lib/brcobranca/retorno/cnab400/bradesco.rb
+++ b/lib/brcobranca/retorno/cnab400/bradesco.rb
@@ -6,7 +6,7 @@ module Brcobranca
       # Formato de Retorno CNAB 400
       # Baseado em: http://www.bradesco.com.br/portal/PDF/pessoajuridica/solucoes-integradas/outros/layout-de-arquivo/cobranca/4008-524-0121-08-layout-cobranca-versao-portugues.pdf
       class Bradesco < Brcobranca::Retorno::Cnab400::Base
-        extend ParseLine::FixedWidth # Extendendo parseline
+        extend ParseLine
 
         # Load lines
         def self.load_lines(file, options = {})

--- a/lib/brcobranca/retorno/cnab400/credisis.rb
+++ b/lib/brcobranca/retorno/cnab400/credisis.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
-require 'parseline'
-
 module Brcobranca
   module Retorno
     module Cnab400
       # Formato de Retorno CNAB 400
       class Credisis < Brcobranca::Retorno::Base
-        extend ParseLine::FixedWidth
+        extend ParseLine
 
         def self.load_lines(file, options = {})
           default_options = { except: [1] } # por padrao ignora a primeira linha que é header

--- a/lib/brcobranca/retorno/cnab400/itau.rb
+++ b/lib/brcobranca/retorno/cnab400/itau.rb
@@ -1,14 +1,12 @@
 # frozen_string_literal: true
 
-require 'parseline'
-
 module Brcobranca
   module Retorno
     module Cnab400
       # Formato de Retorno CNAB 400
       # Baseado em: http://download.itau.com.br/bankline/layout_cobranca_400bytes_cnab_itau_mensagem.pdf
       class Itau < Brcobranca::Retorno::Cnab400::Base
-        extend ParseLine::FixedWidth # Extendendo parseline
+        extend ParseLine
 
         # Load lines
         def self.load_lines(file, options = {})

--- a/lib/brcobranca/retorno/cnab400/santander.rb
+++ b/lib/brcobranca/retorno/cnab400/santander.rb
@@ -1,14 +1,12 @@
 # frozen_string_literal: true
 
-require 'parseline'
-
 module Brcobranca
   module Retorno
     module Cnab400
       # Formato de Retorno CNAB 400
       # Baseado em: http://download.itau.com.br/bankline/layout_cobranca_400bytes_cnab_itau_mensagem.pdf
       class Santander < Brcobranca::Retorno::Cnab400::Base
-        extend ParseLine::FixedWidth # Extendendo parseline
+        extend ParseLine
 
         # Load lines
         def self.load_lines(file, options = {})

--- a/lib/brcobranca/retorno/cnab400/unicred.rb
+++ b/lib/brcobranca/retorno/cnab400/unicred.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
-require 'parseline'
-
 module Brcobranca
   module Retorno
     module Cnab400
       # Formato de Retorno CNAB 400
       class Unicred < Brcobranca::Retorno::Cnab400::Base
-        extend ParseLine::FixedWidth
+        extend ParseLine
 
         def self.load_lines(file, options = {})
           # por padrao ignora a primeira linha que é header

--- a/lib/brcobranca/retorno/retorno_cbr643.rb
+++ b/lib/brcobranca/retorno/retorno_cbr643.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
-require 'parseline'
 module Brcobranca
   module Retorno
     # Formato de Retorno CNAB 643
     class RetornoCbr643 < Base
-      extend ParseLine::FixedWidth # Extendendo parseline
+      extend ParseLine
 
       fixed_width_layout do |parse|
         parse.field :agencia_com_dv, 17..21

--- a/lib/brcobranca/retorno/retorno_cnab240.rb
+++ b/lib/brcobranca/retorno/retorno_cnab240.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'parseline'
 module Brcobranca
   module Retorno
     # Formato de Retorno CNAB 240
@@ -38,7 +37,7 @@ module Brcobranca
       # O primeiro é do tipo T que retorna dados gerais sobre a transação
       # O segundo é do tipo U que retorna os valores da transação
       class Line < Base
-        extend ParseLine::FixedWidth # Extendendo parseline
+        extend ParseLine
 
         REGISTRO_T_FIELDS = %w[codigo_registro codigo_ocorrencia agencia_com_dv cedente_com_dv nosso_numero carteira
                                data_vencimento valor_titulo banco_recebedor agencia_recebedora_com_dv sequencial valor_tarifa motivo_ocorrencia].freeze

--- a/lib/brcobranca/retorno/retorno_cnab240.rb
+++ b/lib/brcobranca/retorno/retorno_cnab240.rb
@@ -11,7 +11,9 @@ module Brcobranca
         default_options = { except: REGEX_DE_EXCLUSAO_DE_REGISTROS_NAO_T_OU_U }
         options = default_options.merge!(options)
 
-        Line.load_lines(file, options).each_slice(2).reduce([]) do |retornos, cnab_lines|
+        # self::Line (e nao Line) para que uma subclasse, como o
+        # Cnab240::Caixa, use o proprio layout em vez do generico.
+        self::Line.load_lines(file, options).each_slice(2).reduce([]) do |retornos, cnab_lines|
           retornos << generate_retorno_based_on_cnab_lines(cnab_lines)
         end
       end
@@ -20,11 +22,11 @@ module Brcobranca
         retorno = new
         cnab_lines.each do |line|
           if line.tipo_registro == 'T'
-            Line::REGISTRO_T_FIELDS.each do |attr|
+            self::Line::REGISTRO_T_FIELDS.each do |attr|
               retorno.send(:"#{attr}=", line.send(attr))
             end
           else
-            Line::REGISTRO_U_FIELDS.each do |attr|
+            self::Line::REGISTRO_U_FIELDS.each do |attr|
               retorno.send(:"#{attr}=", line.send(attr))
             end
           end

--- a/lib/brcobranca/retorno/retorno_cnab400.rb
+++ b/lib/brcobranca/retorno/retorno_cnab400.rb
@@ -6,14 +6,13 @@
 # Classe original desenvolvida a partir do layout do Itau.
 # Movido para: cnab400/itau.rb
 #
-require 'parseline'
 module Brcobranca
   module Retorno
     # Formato de Retorno CNAB 400
 
     # Baseado em: http://download.itau.com.br/bankline/layout_cobranca_400bytes_cnab_itau_mensagem.pdf
     class RetornoCnab400 < Base
-      extend ParseLine::FixedWidth # Extendendo parseline
+      extend ParseLine
 
       def self.load_lines(file, options = {})
         default_options = { except: [1] } # por padrao ignora a primeira linha que é header

--- a/spec/brcobranca/parse_line_spec.rb
+++ b/spec/brcobranca/parse_line_spec.rb
@@ -28,9 +28,41 @@ class SimpleParser
   end
 end
 
+# Classes para testar a heranca do layout entre classe mae e filha
+class ParentParser
+  extend Brcobranca::ParseLine
+
+  attr_accessor :campo_proprio, :campo_sobrescrito
+
+  fixed_width_layout do |layout|
+    layout.field :campo_proprio, 0..4
+    layout.field :campo_sobrescrito, 5..9
+  end
+end
+
+class ChildParser < ParentParser
+  fixed_width_layout do |layout|
+    layout.field :campo_sobrescrito, 10..14
+  end
+end
+
+# Classe para testar o transformador informado como bloco
+class BlockParser
+  extend Brcobranca::ParseLine
+
+  attr_accessor :quantidade
+
+  fixed_width_layout do |layout|
+    layout.field :quantidade, 0..4 do |value|
+      value.to_i * 2
+    end
+  end
+end
+
 # Classe para testar com layout complexo e transformadores que falham
 class FailingParser
   extend Brcobranca::ParseLine
+
   attr_accessor :value
 
   fixed_width_layout do |layout|
@@ -236,12 +268,27 @@ RSpec.describe Brcobranca::ParseLine do
         temp_file.rewind
       end
 
-      it 'considera apenas linhas com o tamanho especificado (usando line.size - 2)' do
+      it 'considera apenas linhas com o tamanho especificado' do
         results = TestParser.load_lines(temp_file.path, length: 50)
 
         expect(results.size).to eq(2)
         expect(results[0].name).to eq('João Silva')
         expect(results[1].name).to eq('Maria Santos')
+      end
+    end
+
+    context 'com filtro :length e brancos a direita' do
+      before do
+        # registro preenchido com brancos a direita, como num arquivo CNAB
+        temp_file.write("#{'João Silva          00025São Paulo         12'.ljust(50, ' ')}\r\n")
+        temp_file.rewind
+      end
+
+      it 'nao descarta a linha por causa do preenchimento' do
+        results = TestParser.load_lines(temp_file.path, length: 50)
+
+        expect(results.size).to eq(1)
+        expect(results[0].name).to eq('João Silva')
       end
     end
 
@@ -442,6 +489,40 @@ RSpec.describe Brcobranca::ParseLine do
         expect(result.active).to be(false)
         expect(result.date).to be_nil
       end
+    end
+  end
+
+  describe 'heranca do layout' do
+    it 'a classe filha comeca com os campos da classe mae' do
+      campos = ChildParser.parse_values.map(&:first)
+
+      expect(campos).to include(:campo_proprio)
+    end
+
+    it 'o campo redefinido na filha vence o da mae' do
+      ranges = ChildParser.parse_values.each_with_object({}) { |(campo, range, _), acc| acc[campo] = range }
+
+      expect(ranges[:campo_sobrescrito]).to eq(10..14)
+    end
+
+    it 'definir campo na filha nao altera o layout da mae' do
+      ranges = ParentParser.parse_values.each_with_object({}) { |(campo, range, _), acc| acc[campo] = range }
+
+      expect(ParentParser.parse_values.size).to eq(2)
+      expect(ranges[:campo_sobrescrito]).to eq(5..9)
+    end
+
+    it 'a filha realmente usa o proprio layout ao parsear' do
+      result = ChildParser.load_line('AAAAABBBBBCCCCC')
+
+      expect(result.campo_proprio).to eq('AAAAA')
+      expect(result.campo_sobrescrito).to eq('CCCCC')
+    end
+  end
+
+  describe 'transformador informado como bloco' do
+    it 'aplica o bloco ao valor do campo' do
+      expect(BlockParser.load_line('00021').quantidade).to eq(42)
     end
   end
 end

--- a/spec/brcobranca/parse_line_spec.rb
+++ b/spec/brcobranca/parse_line_spec.rb
@@ -75,18 +75,18 @@ RSpec.describe Brcobranca::ParseLine do
     end
 
     it 'define os campos corretamente' do
-      expect(TestParser.class_variable_get(:@@parse_values)).to be_an(Array)
-      expect(TestParser.class_variable_get(:@@parse_values).size).to eq(4)
+      expect(TestParser.parse_values).to be_an(Array)
+      expect(TestParser.parse_values.size).to eq(4)
     end
   end
 
   describe '.field' do
     it 'adiciona um campo ao layout' do
-      expect(SimpleParser.class_variable_get(:@@parse_values).size).to eq(2)
+      expect(SimpleParser.parse_values.size).to eq(2)
     end
 
     it 'armazena o nome do campo, range e transformador' do
-      field_definition = TestParser.class_variable_get(:@@parse_values).first
+      field_definition = TestParser.parse_values.first
       expect(field_definition[0]).to eq(:name)
       expect(field_definition[1]).to eq(0..19)
     end

--- a/spec/brcobranca/parse_line_spec.rb
+++ b/spec/brcobranca/parse_line_spec.rb
@@ -1,0 +1,447 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Classe de exemplo para testar o módulo ParseLine
+class TestParser
+  extend Brcobranca::ParseLine
+
+  attr_accessor :name, :age, :city, :amount
+
+  fixed_width_layout do |layout|
+    layout.field :name, 0..19
+    layout.field :age, 20..24, lambda(&:to_i)
+    layout.field :city, 25..39
+    layout.field :amount, 40..50, lambda(&:to_f)
+  end
+end
+
+# Classe para testar com layout simples sem transformadores
+class SimpleParser
+  extend Brcobranca::ParseLine
+
+  attr_accessor :field1, :field2
+
+  fixed_width_layout do |layout|
+    layout.field :field1, 0..9
+    layout.field :field2, 10..19
+  end
+end
+
+# Classe para testar com layout complexo e transformadores que falham
+class FailingParser
+  extend Brcobranca::ParseLine
+  attr_accessor :value
+
+  fixed_width_layout do |layout|
+    layout.field :value, 0..9, lambda { |_v|
+      raise StandardError, 'Erro no transformador'
+    }
+  end
+end
+
+# Classe para testar com layout complexo e transformadores
+class BankReturnParser
+  extend Brcobranca::ParseLine
+
+  attr_accessor :record_type, :document, :amount, :due_date
+
+  fixed_width_layout do |layout|
+    layout.field :record_type, 0..0
+    layout.field :document, 1..14
+    layout.field :amount, 15..27, ->(value) { value.to_f / 100 }
+    layout.field :due_date, 28..35
+  end
+end
+
+# Classe para testar com múltiplos transformadores complexos
+class ComplexParser
+  extend Brcobranca::ParseLine
+
+  attr_accessor :name, :price, :active, :date
+
+  fixed_width_layout do |layout|
+    layout.field :name, 0..19, ->(value) { value.strip.upcase }
+    layout.field :price, 20..29, ->(value) { value.to_f.round(2) }
+    layout.field :active, 30..30, ->(value) { value == 'S' }
+    layout.field :date, 31..40, ->(value) { value.strip.empty? ? nil : Date.parse(value) }
+  end
+end
+
+RSpec.describe Brcobranca::ParseLine do
+  describe '.fixed_width_layout' do
+    it 'permite definir um layout com campos' do
+      expect(TestParser).to respond_to(:fixed_width_layout)
+    end
+
+    it 'define os campos corretamente' do
+      expect(TestParser.class_variable_get(:@@parse_values)).to be_an(Array)
+      expect(TestParser.class_variable_get(:@@parse_values).size).to eq(4)
+    end
+  end
+
+  describe '.field' do
+    it 'adiciona um campo ao layout' do
+      expect(SimpleParser.class_variable_get(:@@parse_values).size).to eq(2)
+    end
+
+    it 'armazena o nome do campo, range e transformador' do
+      field_definition = TestParser.class_variable_get(:@@parse_values).first
+      expect(field_definition[0]).to eq(:name)
+      expect(field_definition[1]).to eq(0..19)
+    end
+  end
+
+  describe '.load_line' do
+    context 'com dados válidos' do
+      let(:line) { 'João Silva          00025São Paulo         001234.5  ' }
+
+      it 'parseia uma linha corretamente' do
+        result = TestParser.load_line(line)
+
+        expect(result).to be_a(TestParser)
+        expect(result.name).to eq('João Silva')
+        expect(result.age).to eq(25)
+        expect(result.city).to eq('São Paulo')
+        expect(result.amount).to eq(1234.5)
+      end
+
+      it 'remove espaços em branco dos campos sem transformador' do
+        result = TestParser.load_line(line)
+        expect(result.name).to eq('João Silva')
+        expect(result.city).to eq('São Paulo')
+      end
+
+      it 'aplica transformadores quando definidos' do
+        result = TestParser.load_line(line)
+        expect(result.age).to be_an(Integer)
+        expect(result.amount).to be_a(Float)
+      end
+    end
+
+    context 'com linha vazia ou com apenas espaços' do
+      let(:line) { ' ' * 50 }
+
+      it 'parseia linha vazia sem erros' do
+        result = TestParser.load_line(line)
+
+        expect(result.name).to eq('')
+        expect(result.age).to eq(0)
+        expect(result.city).to eq('')
+        expect(result.amount).to eq(0.0)
+      end
+    end
+
+    context 'com linha malformada' do
+      let(:short_line) { 'abc' }
+
+      it 'parseia linha curta sem erros (retorna valores vazios)' do
+        result = TestParser.load_line(short_line)
+        expect(result).to be_a(TestParser)
+        expect(result.name).to eq('abc')
+        expect(result.age).to eq(0)
+      end
+    end
+
+    context 'quando o transformador falha' do
+      it 'captura e relança o erro com mais contexto' do
+        expect { FailingParser.load_line('test      ') }.to raise_error(
+          Brcobranca::MalformedLayoutOrLine,
+          /Erro original: \(StandardError\): Erro no transformador/
+        )
+      end
+    end
+  end
+
+  describe '.load_lines' do
+    let(:temp_file) { Tempfile.new(['test_parse', '.txt']) }
+
+    after do
+      temp_file.close
+      temp_file.unlink
+    end
+
+    context 'sem filtros' do
+      before do
+        temp_file.write("João Silva          00025São Paulo         001234.56 \n")
+        temp_file.write("Maria Santos        00030Rio de Janeiro    002345.67 \n")
+        temp_file.write("Pedro Costa         00040Belo Horizonte    003456.78 \n")
+        temp_file.rewind
+      end
+
+      it 'carrega todas as linhas do arquivo' do
+        results = TestParser.load_lines(temp_file.path)
+
+        expect(results.size).to eq(3)
+        expect(results[0].name).to eq('João Silva')
+        expect(results[1].name).to eq('Maria Santos')
+        expect(results[2].name).to eq('Pedro Costa')
+      end
+
+      it 'retorna um array de objetos parseados' do
+        results = TestParser.load_lines(temp_file.path)
+
+        expect(results).to all(be_a(TestParser))
+      end
+    end
+
+    context 'com filtro :except como array' do
+      before do
+        temp_file.write("Header linha        00000Ignorar           000000.00 \n")
+        temp_file.write("João Silva          00025São Paulo         001234.56 \n")
+        temp_file.write("Maria Santos        00030Rio de Janeiro    002345.67 \n")
+        temp_file.write("Footer linha        00000Ignorar           000000.00 \n")
+        temp_file.rewind
+      end
+
+      it 'ignora as linhas especificadas no array' do
+        results = TestParser.load_lines(temp_file.path, except: [1, 4])
+
+        expect(results.size).to eq(2)
+        expect(results[0].name).to eq('João Silva')
+        expect(results[1].name).to eq('Maria Santos')
+      end
+
+      it 'usa índice baseado em 1' do
+        results = TestParser.load_lines(temp_file.path, except: [1])
+
+        expect(results.size).to eq(3)
+        expect(results[0].name).to eq('João Silva')
+      end
+    end
+
+    context 'com filtro :except como regex' do
+      before do
+        temp_file.write("HEADER linha        00000Ignorar           000000.00 \n")
+        temp_file.write("João Silva          00025São Paulo         001234.56 \n")
+        temp_file.write("Maria Santos        00030Rio de Janeiro    002345.67 \n")
+        temp_file.write("FOOTER linha        00000Ignorar           000000.00 \n")
+        temp_file.rewind
+      end
+
+      it 'ignora as linhas que correspondem ao regex' do
+        results = TestParser.load_lines(temp_file.path, except: /^(HEADER|FOOTER)/)
+
+        expect(results.size).to eq(2)
+        expect(results[0].name).to eq('João Silva')
+        expect(results[1].name).to eq('Maria Santos')
+      end
+    end
+
+    context 'com filtro :length' do
+      before do
+        temp_file.write("João Silva          00025São Paulo         1234.56\n")
+        temp_file.write("abc\n")
+        temp_file.write("Maria Santos        00030Rio de Janeiro    2345.67\n")
+        temp_file.rewind
+      end
+
+      it 'considera apenas linhas com o tamanho especificado (usando line.size - 2)' do
+        results = TestParser.load_lines(temp_file.path, length: 50)
+
+        expect(results.size).to eq(2)
+        expect(results[0].name).to eq('João Silva')
+        expect(results[1].name).to eq('Maria Santos')
+      end
+    end
+
+    context 'com linhas em branco' do
+      before do
+        temp_file.write("João Silva          00025São Paulo         001234.56 \n")
+        temp_file.write("\n")
+        temp_file.write("Maria Santos        00030Rio de Janeiro    002345.67 \n")
+        temp_file.rewind
+      end
+
+      it 'ignora linhas em branco ao usar filtro except array' do
+        results = TestParser.load_lines(temp_file.path, except: [])
+
+        expect(results.size).to eq(2)
+      end
+
+      it 'ignora linhas em branco ao usar filtro except regex' do
+        results = TestParser.load_lines(temp_file.path, except: /^$/)
+
+        expect(results.size).to eq(2)
+      end
+    end
+
+    context 'com combinacao de filtros' do
+      before do
+        temp_file.write("HEADER linha        00000Ignorar           0000.00\n")
+        temp_file.write("João Silva          00025São Paulo         1234.56\n")
+        temp_file.write("abc\n")
+        temp_file.write("Maria Santos        00030Rio de Janeiro    2345.67\n")
+        temp_file.write("FOOTER linha        00000Ignorar           0000.00\n")
+        temp_file.rewind
+      end
+
+      it 'except regex e length' do
+        results = TestParser.load_lines(temp_file.path, except: /^(HEADER|FOOTER)/, length: 50)
+
+        expect(results.size).to eq(2)
+        expect(results[0].name).to eq('João Silva')
+        expect(results[1].name).to eq('Maria Santos')
+      end
+
+      it 'except array e length' do
+        results = TestParser.load_lines(temp_file.path, except: [1, 5], length: 50)
+
+        expect(results.size).to eq(2)
+        expect(results[0].name).to eq('João Silva')
+        expect(results[1].name).to eq('Maria Santos')
+      end
+    end
+  end
+
+  describe '.load_lines_except_array' do
+    let(:temp_file) { Tempfile.new(['test_parse', '.txt']) }
+
+    after do
+      temp_file.close
+      temp_file.unlink
+    end
+
+    before do
+      temp_file.write("Header              00000Ignorar           0000.00\n")
+      temp_file.write("João Silva          00025São Paulo         1234.56\n")
+      temp_file.write("\n")
+      temp_file.write("Maria Santos        00030Rio de Janeiro    2345.67\n")
+      temp_file.rewind
+    end
+
+    it 'exclui linhas baseadas em índices (1-based)' do
+      results = TestParser.load_lines_except_array(temp_file.path, [1, 3])
+
+      expect(results.size).to eq(2)
+      expect(results[0].name).to eq('João Silva')
+      expect(results[1].name).to eq('Maria Santos')
+    end
+
+    it 'ignora linhas em branco' do
+      results = TestParser.load_lines_except_array(temp_file.path, [1])
+
+      expect(results.size).to eq(2)
+    end
+
+    it 'respeita o filtro de length quando fornecido' do
+      results = TestParser.load_lines_except_array(temp_file.path, [1], 50)
+
+      expect(results.size).to eq(2)
+      expect(results.all?(TestParser)).to be(true)
+    end
+  end
+
+  describe '.load_lines_except_regex' do
+    let(:temp_file) { Tempfile.new(['test_parse', '.txt']) }
+
+    after do
+      temp_file.close
+      temp_file.unlink
+    end
+
+    before do
+      temp_file.write("HEADER              00000Ignorar           0000.00\n")
+      temp_file.write("João Silva          00025São Paulo         1234.56\n")
+      temp_file.write("\n")
+      temp_file.write("FOOTER              00000Ignorar           0000.00\n")
+      temp_file.rewind
+    end
+
+    it 'exclui linhas que correspondem ao regex' do
+      results = TestParser.load_lines_except_regex(temp_file.path, /^(HEADER|FOOTER)/)
+
+      expect(results.size).to eq(1)
+      expect(results[0].name).to eq('João Silva')
+    end
+
+    it 'ignora linhas em branco' do
+      results = TestParser.load_lines_except_regex(temp_file.path, /^NONEXISTENT/)
+
+      expect(results.size).to eq(3)
+    end
+
+    it 'respeita o filtro de length quando fornecido' do
+      results = TestParser.load_lines_except_regex(temp_file.path, /^(HEADER|FOOTER)/, 50)
+
+      expect(results.size).to eq(1)
+      expect(results[0].name).to eq('João Silva')
+    end
+  end
+
+  describe '.line_length_valid?' do
+    it 'retorna true quando expected_length é nil' do
+      expect(TestParser.line_length_valid?('qualquer linha', nil)).to be(true)
+    end
+
+    it 'retorna true quando o tamanho da linha corresponde' do
+      line = "#{'a' * 50}\n"
+      expect(TestParser.line_length_valid?(line, 50)).to be(true)
+    end
+
+    it 'retorna false quando o tamanho da linha não corresponde' do
+      line = "#{'a' * 30}\n"
+      expect(TestParser.line_length_valid?(line, 50)).to be(false)
+    end
+
+    it 'calcula corretamente para linhas de tamanhos diferentes' do
+      line = "#{'a' * 48}\n"
+      expect(TestParser.line_length_valid?(line, 47)).to be(false)
+      expect(TestParser.line_length_valid?(line, 48)).to be(true)
+      expect(TestParser.line_length_valid?(line, 49)).to be(false)
+    end
+  end
+
+  describe 'casos de uso práticos' do
+    context 'quando parseando arquivo de retorno bancário simplificado' do
+      let(:temp_file) { Tempfile.new(['bank_return', '.ret']) }
+
+      after do
+        temp_file.close
+        temp_file.unlink
+      end
+
+      before do
+        temp_file.write("0              14\n") # Header
+        temp_file.write("112345678901234000000012345620250101\n") # Detail
+        temp_file.write("112345678901235000000067890120250115\n") # Detail
+        temp_file.write("9              02\n") # Footer
+        temp_file.rewind
+      end
+
+      it 'parseia corretamente arquivo de retorno' do
+        results = BankReturnParser.load_lines(temp_file.path, except: /^[09]/)
+
+        expect(results.size).to eq(2)
+        expect(results[0].record_type).to eq('1')
+        expect(results[0].document).to eq('12345678901234')
+        expect(results[0].amount).to eq(1234.56)
+        expect(results[0].due_date).to eq('20250101')
+
+        expect(results[1].amount).to eq(6789.01)
+      end
+    end
+
+    context 'com múltiplos transformadores complexos' do
+      it 'aplica todos os transformadores corretamente' do
+        line = 'produto teste       123.45678 S2025-02-01'
+        result = ComplexParser.load_line(line)
+
+        expect(result.name).to eq('PRODUTO TESTE')
+        expect(result.price).to eq(123.46)
+        expect(result.active).to be(true)
+        expect(result.date).to eq(Date.new(2025, 2, 1))
+      end
+
+      it 'trata valores vazios nos transformadores' do
+        line = 'produto             000.00000 N          '
+        result = ComplexParser.load_line(line)
+
+        expect(result.name).to eq('PRODUTO')
+        expect(result.price).to eq(0.0)
+        expect(result.active).to be(false)
+        expect(result.date).to be_nil
+      end
+    end
+  end
+end

--- a/spec/brcobranca/retorno/cnab240/caixa_spec.rb
+++ b/spec/brcobranca/retorno/cnab240/caixa_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Brcobranca::Retorno::Cnab240::Caixa do
+  # A Caixa reaproveita o layout generico do CNAB 240 e sobrescreve apenas
+  # alguns campos. Estes exemplos garantem que o reaproveitamento continua
+  # valendo e, principalmente, que ele nao vaza para o layout generico.
+  let(:layout_caixa) do
+    described_class::Line.parse_values.each_with_object({}) { |(campo, range, _), acc| acc[campo] = range }
+  end
+
+  let(:layout_generico) do
+    Brcobranca::Retorno::RetornoCnab240::Line.parse_values
+                                             .each_with_object({}) { |(campo, range, _), acc| acc[campo] = range }
+  end
+
+  it 'herda os campos do layout generico do CNAB 240' do
+    expect(layout_caixa.keys).to include(:data_vencimento, :valor_titulo, :banco_recebedor, :valor_tarifa)
+  end
+
+  it 'sobrescreve o nosso numero com as posicoes da Caixa' do
+    expect(layout_caixa[:nosso_numero]).to eq(39..55)
+  end
+
+  it 'sobrescreve a agencia recebedora com as posicoes da Caixa' do
+    expect(layout_caixa[:agencia_recebedora_com_dv]).to eq(99..103)
+  end
+
+  it 'nao altera o layout generico do CNAB 240' do
+    expect(layout_generico[:nosso_numero]).to eq(46..56)
+    expect(layout_generico[:agencia_recebedora_com_dv]).to eq(99..104)
+  end
+
+  context 'quando le um arquivo' do
+    let(:arquivo) do
+      file = Tempfile.new(['retorno_caixa', '.RET'])
+      file.write("#{registro('T')}\r\n#{registro('U')}\r\n")
+      file.rewind
+      file
+    end
+
+    after do
+      arquivo.close
+      arquivo.unlink
+    end
+
+    # Registro de 240 posicoes reconhecido pelo filtro do CNAB 240:
+    # posicao 8 = '3' (detalhe) e posicao 14 = segmento T ou U.
+    def registro(segmento)
+      linha = '0' * 240
+      linha[7] = '3'
+      linha[13] = segmento
+      linha[39..55] = '12345678901234567' # nosso numero na posicao da Caixa
+      linha[99..104] = '987654'           # agencia recebedora + 1 digito
+      linha
+    end
+
+    it 'usa o layout da Caixa, e nao o generico' do
+      retornos = described_class.load_lines(arquivo.path)
+
+      expect(retornos.size).to eq(1)
+      expect(retornos.first.nosso_numero).to eq('12345678901234567')
+      expect(retornos.first.agencia_recebedora_com_dv).to eq('98765')
+    end
+  end
+end


### PR DESCRIPTION
Remove a gem [parseline](https://github.com/shairontoledo/parseline) do projeto e o módulo `ParseLine::FixedWidth` incorporado por 3 motivos principais.

1. O primeiro é que projeto não é atualizado desde 2009.
2. A parte da biblioteca que o `brcobranca` usa é apenas um módulo simples.
3. Vou propor novas funcionalidades para os arquivos retorno e vai ser mais fácil se o código de parser estiver presente internamente.

## Resumo por Sourcery

Substitui a dependência não mantida `parseline` por um analisador interno de largura fixa para arquivos de retorno bancário.

Novos recursos:
- Adiciona um analisador interno de largura fixa para definir layouts, transformar valores de campos, filtrar linhas de entrada e oferecer suporte a layouts herdados.
- Gera um erro dedicado quando uma linha de retorno não pode ser analisada de acordo com seu layout.

Melhorias:
- Migra os leitores de retorno CNAB240 e CNAB400 do mixin do analisador externo para o módulo interno `ParseLine`.
- Preserva a herança independente de layouts e as substituições específicas de cada banco para os formatos de retorno CNAB.

Build:
- Remove a dependência de runtime `parseline` da especificação da gem e do arquivo de lock.

Testes:
- Adiciona cobertura abrangente para análise de largura fixa, filtragem de linhas, transformações de valores, tratamento de entradas malformadas, herança de layouts e layouts Caixa CNAB240.

Tarefas:
- Atualiza a configuração do RuboCop para o estilo atual do projeto e as convenções do RSpec.

<details>
<summary>Original summary in English</summary>

## Resumo por Sourcery

Substitui a dependência não mantida `parseline` por um analisador interno de largura fixa para arquivos de retorno bancário.

Novos recursos:
- Adiciona um analisador interno de largura fixa para arquivos de retorno bancário, com transformações de campos, filtragem de entradas e layouts herdados.
- Gera um erro dedicado quando uma linha de retorno não pode ser processada de acordo com seu layout.

Melhorias:
- Migra os leitores de retorno CNAB240 e CNAB400 do analisador externo para o módulo interno `ParseLine`, preservando as substituições e a herança de layouts específicas de cada banco.

Build:
- Remove a dependência de execução `parseline` da especificação da gem e do arquivo de lock.

Testes:
- Adiciona cobertura abrangente para análise de largura fixa, filtragem, transformações, entradas malformadas, herança de layouts e layouts Caixa CNAB240.

Tarefas:
- Atualiza as configurações do RuboCop e do RSpec para corresponder às convenções atuais do projeto.

<details>
<summary>Original summary in English</summary>

## Resumo por Sourcery

Substitui a dependência não mantida `parseline` por um analisador interno de largura fixa para arquivos de retorno bancário.

Novos recursos:
- Adiciona um analisador interno de largura fixa para arquivos de retorno e remessa bancária, com transformações de campos, filtragem de linhas e layouts herdados.
- Introduz um erro específico para linhas malformadas ou layouts incompatíveis.

Melhorias:
- Migra os leitores de retorno CNAB240 e CNAB400 para o analisador interno, preservando os layouts e as substituições específicas de cada banco.

Build:
- Remove a dependência de runtime `parseline` da especificação da gem e do lockfile.

Testes:
- Adiciona cobertura abrangente para análise de largura fixa, filtragem, transformações, entradas malformadas, herança de layouts e layouts Caixa CNAB240.

Tarefas:
- Atualiza as configurações do RuboCop e do RSpec para corresponder às convenções atuais do projeto.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace the unmaintained parseline dependency with an internal fixed-width parser for banking return files.

New Features:
- Add an internal fixed-width parser for banking return and remittance files with field transformations, line filtering, and inherited layouts.
- Introduce a dedicated error for malformed lines or incompatible layouts.

Enhancements:
- Migrate CNAB240 and CNAB400 return readers to the internal parser while preserving bank-specific layouts and overrides.

Build:
- Remove the parseline runtime dependency from the gem specification and lockfile.

Tests:
- Add comprehensive coverage for fixed-width parsing, filtering, transformations, malformed input, layout inheritance, and Caixa CNAB240 layouts.

Chores:
- Update RuboCop and RSpec configuration to match current project conventions.

</details>

</details>

</details>

Novos recursos:
- Introduz um módulo interno ParseLine para definir layouts de largura fixa e fazer o parse de linhas de retorno/remessa, com suporte a filtragem de linhas carregadas e transformação de valores de campos.
- Adiciona um erro MalformedLayoutOrLine para sinalizar problemas ao fazer o parse de linhas de retorno em relação aos seus layouts definidos.

Melhorias:
- Atualiza todas as classes CNAB240 e CNAB400 de retorno para usar o novo módulo interno ParseLine em vez do mixin externo ParseLine::FixedWidth.
- Relaxa a configuração do RuboCop desabilitando Style/SuperArguments e normalizando o estilo de strings em require.

Build:
- Remove a dependência de runtime da parseline do gemspec.

<details>
<summary>Original summary in English</summary>

## Resumo por Sourcery

Substitui a dependência não mantida `parseline` por um analisador interno de largura fixa para arquivos de retorno bancário.

Novos recursos:
- Adiciona um analisador interno de largura fixa para definir layouts, transformar valores de campos, filtrar linhas de entrada e oferecer suporte a layouts herdados.
- Gera um erro dedicado quando uma linha de retorno não pode ser analisada de acordo com seu layout.

Melhorias:
- Migra os leitores de retorno CNAB240 e CNAB400 do mixin do analisador externo para o módulo interno `ParseLine`.
- Preserva a herança independente de layouts e as substituições específicas de cada banco para os formatos de retorno CNAB.

Build:
- Remove a dependência de runtime `parseline` da especificação da gem e do arquivo de lock.

Testes:
- Adiciona cobertura abrangente para análise de largura fixa, filtragem de linhas, transformações de valores, tratamento de entradas malformadas, herança de layouts e layouts Caixa CNAB240.

Tarefas:
- Atualiza a configuração do RuboCop para o estilo atual do projeto e as convenções do RSpec.

<details>
<summary>Original summary in English</summary>

## Resumo por Sourcery

Substitui a dependência não mantida `parseline` por um analisador interno de largura fixa para arquivos de retorno bancário.

Novos recursos:
- Adiciona um analisador interno de largura fixa para arquivos de retorno bancário, com transformações de campos, filtragem de entradas e layouts herdados.
- Gera um erro dedicado quando uma linha de retorno não pode ser processada de acordo com seu layout.

Melhorias:
- Migra os leitores de retorno CNAB240 e CNAB400 do analisador externo para o módulo interno `ParseLine`, preservando as substituições e a herança de layouts específicas de cada banco.

Build:
- Remove a dependência de execução `parseline` da especificação da gem e do arquivo de lock.

Testes:
- Adiciona cobertura abrangente para análise de largura fixa, filtragem, transformações, entradas malformadas, herança de layouts e layouts Caixa CNAB240.

Tarefas:
- Atualiza as configurações do RuboCop e do RSpec para corresponder às convenções atuais do projeto.

<details>
<summary>Original summary in English</summary>

## Resumo por Sourcery

Substitui a dependência não mantida `parseline` por um analisador interno de largura fixa para arquivos de retorno bancário.

Novos recursos:
- Adiciona um analisador interno de largura fixa para arquivos de retorno e remessa bancária, com transformações de campos, filtragem de linhas e layouts herdados.
- Introduz um erro específico para linhas malformadas ou layouts incompatíveis.

Melhorias:
- Migra os leitores de retorno CNAB240 e CNAB400 para o analisador interno, preservando os layouts e as substituições específicas de cada banco.

Build:
- Remove a dependência de runtime `parseline` da especificação da gem e do lockfile.

Testes:
- Adiciona cobertura abrangente para análise de largura fixa, filtragem, transformações, entradas malformadas, herança de layouts e layouts Caixa CNAB240.

Tarefas:
- Atualiza as configurações do RuboCop e do RSpec para corresponder às convenções atuais do projeto.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace the unmaintained parseline dependency with an internal fixed-width parser for banking return files.

New Features:
- Add an internal fixed-width parser for banking return and remittance files with field transformations, line filtering, and inherited layouts.
- Introduce a dedicated error for malformed lines or incompatible layouts.

Enhancements:
- Migrate CNAB240 and CNAB400 return readers to the internal parser while preserving bank-specific layouts and overrides.

Build:
- Remove the parseline runtime dependency from the gem specification and lockfile.

Tests:
- Add comprehensive coverage for fixed-width parsing, filtering, transformations, malformed input, layout inheritance, and Caixa CNAB240 layouts.

Chores:
- Update RuboCop and RSpec configuration to match current project conventions.

</details>

</details>

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Novas Funcionalidades**
  * Nova DSL para interpretar linhas de largura fixa, com definição de campos, transformações, validações e carregamento em lote.
  * Suporte aprimorado a layouts bancários CNAB240 e CNAB400, incluindo variações específicas do Itaú e da Caixa.
  * Novo erro público para identificar linhas ou layouts inválidos.

* **Refatoração**
  * Processamento de arquivos e layouts unificado entre diferentes formatos bancários.

* **Testes**
  * Ampla cobertura para layouts, transformações, filtros, herança e tratamento de erros.

* **Style**
  * Regras de lint e RSpec atualizadas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->