### PR TITLE
feat: Adiciona Template Prawn como alternativa ao RGhost (Bolepix)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,16 @@ group :development do
   gem 'rubocop-rspec'
 end
 
+# Gems opcionais para o template PrawnBolepix (alternativa ao RGhost).
+# Não requer GhostScript. Usuários devem adicioná-las ao próprio Gemfile.
+group :development, :test do
+  gem 'barby'
+  gem 'chunky_png'
+  gem 'prawn'
+  gem 'prawn-table'
+  gem 'rqrcode'
+end
+
 group :test do
   gem 'code-scanning-rubocop'
   gem 'json'

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :development do
 end
 
 # Gems opcionais para o template PrawnBolepix (alternativa ao RGhost).
-# Não requer GhostScript. Usuários devem adicioná-las ao próprio Gemfile.
+# Nao requer GhostScript. Usuarios devem adiciona-las ao proprio Gemfile.
 group :development, :test do
   gem 'barby'
   gem 'chunky_png'

--- a/lib/brcobranca.rb
+++ b/lib/brcobranca.rb
@@ -123,6 +123,7 @@ module Brcobranca
       autoload :Rghost2,     'brcobranca/boleto/template/rghost2'
       autoload :RghostCarne, 'brcobranca/boleto/template/rghost_carne'
       autoload :RghostBolepix, 'brcobranca/boleto/template/rghost_bolepix'
+      autoload :PrawnBolepix, 'brcobranca/boleto/template/prawn_bolepix'
     end
   end
 

--- a/lib/brcobranca/boleto/template/prawn_bolepix.rb
+++ b/lib/brcobranca/boleto/template/prawn_bolepix.rb
@@ -57,17 +57,17 @@ module Brcobranca
 
         # ==================== CORES ====================
         # Cinza muito claro para fundos de cabecalhos/labels
-        COR_FUNDO_LABEL = 'F5F5F5'
+        COR_FUNDO_LABEL = "F5F5F5"
         # Cinza claro para cabecalho principal (barra de topo)
-        COR_FUNDO_CABECALHO = 'EEEEEE'
+        COR_FUNDO_CABECALHO = "EEEEEE"
         # Cinza para texto de labels
-        COR_TEXTO_LABEL = '555555'
+        COR_TEXTO_LABEL = "555555"
         # Preto para valores
-        COR_TEXTO_VALOR = '000000'
+        COR_TEXTO_VALOR = "000000"
         # Cinza para bordas
-        COR_BORDA = '333333'
+        COR_BORDA = "333333"
         # Verde escuro (tipo Sicoob) para destaque do PIX
-        COR_PIX = '006B3F'
+        COR_PIX = "006B3F"
 
         def to(formato, _options = {})
           unless PRAWN_AVAILABLE
@@ -113,9 +113,9 @@ module Brcobranca
             page_size: "A4",
             margin: [PAGE_MARGIN, PAGE_MARGIN, PAGE_MARGIN, PAGE_MARGIN],
             info: {
-              Title: 'Boleto Bancario (Bolepix)',
-              Creator: 'brcobranca',
-              Producer: 'Prawn + RQRCode + Barby'
+              Title: "Boleto Bancario (Bolepix)",
+              Creator: "brcobranca",
+              Producer: "Prawn + RQRCode + Barby"
             }
           )
         end
@@ -138,7 +138,7 @@ module Brcobranca
         # Contem: topo, beneficiario, dados do documento, carteira, sacado,
         # instrucoes reduzidas e autenticacao mecanica (Recibo do Pagador).
         def desenha_recibo_pagador(pdf, boleto)
-          desenha_topo(pdf, boleto, titulo_direito: 'Recibo do Pagador')
+          desenha_topo(pdf, boleto, titulo_direito: "Recibo do Pagador")
           desenha_linha_beneficiario(pdf, boleto)
           desenha_linha_documento(pdf, boleto)
           desenha_linha_carteira(pdf, boleto)
@@ -162,7 +162,7 @@ module Brcobranca
 
           # Texto "Corte aqui"
           pdf.fill_color COR_TEXTO_LABEL
-          pdf.text_box 'Corte aqui --->',
+          pdf.text_box "Corte aqui --->" ,
                        at: [width - 60, y + 3],
                        width: 60,
                        height: 8,
@@ -214,7 +214,7 @@ module Brcobranca
           pdf.stroke_rectangle([0, y], width, altura)
 
           pdf.fill_color COR_TEXTO_LABEL
-          pdf.text_box 'Autenticacao mecanica - Recibo do Pagador',
+          pdf.text_box "Autenticacao mecanica - Recibo do Pagador",
                        at: [4, y - 4],
                        width: width - 8,
                        height: altura - 4,
@@ -265,7 +265,7 @@ module Brcobranca
           desenha_logo_banco(pdf, boleto, 0, y, logo_w, HEADER_HEIGHT)
 
           # Codigo do banco - DV (centro, destaque)
-          pdf.fill_color 'FFFFFF'
+          pdf.fill_color "FFFFFF"
           pdf.fill_rectangle([logo_w, y], codigo_w, HEADER_HEIGHT)
           pdf.fill_color COR_TEXTO_VALOR
 
@@ -279,7 +279,7 @@ module Brcobranca
                        style: :bold
 
           # Linha digitavel (direita, fundo branco)
-          pdf.fill_color 'FFFFFF'
+          pdf.fill_color "FFFFFF"
           pdf.fill_rectangle([logo_w + codigo_w, y], width - logo_w - codigo_w, HEADER_HEIGHT)
           pdf.fill_color COR_TEXTO_VALOR
 
@@ -305,13 +305,17 @@ module Brcobranca
           pdf.move_down HEADER_HEIGHT
         end
 
-        def desenha_logo_banco(pdf, boleto, x, y, col_width, altura)
-          png_path = boleto.logotipo.sub(/\.eps\z/, '.png')
+        def desenha_logo_banco(pdf, boleto, pos_x, pos_y,
+                               col_width, altura)
+          png_path = boleto.logotipo.sub(/\.eps\z/, ".png")
           if File.exist?(png_path)
-            pdf.image png_path, at: [x + 2, y - 2], height: altura - 6, width: col_width - 4
+            pdf.image png_path,
+                      at: [pos_x + 2, pos_y - 2],
+                      height: altura - 6,
+                      width: col_width - 4
           else
             pdf.text_box nome_banco_para_logo(boleto),
-                         at: [x, y - 6],
+                         at: [pos_x, pos_y - 6],
                          width: col_width,
                          height: altura,
                          size: 8,
@@ -321,7 +325,7 @@ module Brcobranca
           end
         rescue StandardError
           pdf.text_box nome_banco_para_logo(boleto),
-                       at: [x, y - 6],
+                       at: [pos_x, pos_y - 6],
                        width: col_width,
                        height: altura,
                        size: 8,
@@ -377,14 +381,13 @@ module Brcobranca
 
         def desenha_linha_documento(pdf, boleto)
           draw_row(pdf, [
-                     { label: 'Data do documento', value: boleto.data_documento&.to_s_br || '', width_ratio: 0.14 },
-                     { label: 'N. do Documento', value: boleto.documento_numero.to_s, width_ratio: 0.22 },
-                     { label: 'Especie', value: boleto.especie_documento.to_s, width_ratio: 0.08 },
-                     { label: 'Aceite', value: boleto.aceite.to_s, width_ratio: 0.07 },
-                     { label: 'Data Processamento', value: boleto.data_processamento&.to_s_br || '', width_ratio: 0.14 },
+                     { label: "Data do documento", value: boleto.data_documento&.to_s_br || "", width_ratio: 0.14 },
+                     { label: "N. do Documento", value: boleto.documento_numero.to_s, width_ratio: 0.22 },
+                     { label: "Especie", value: boleto.especie_documento.to_s, width_ratio: 0.08 },
+                     { label: "Aceite", value: boleto.aceite.to_s, width_ratio: 0.07 },
+                     { label: "Data Processamento", value: boleto.data_processamento&.to_s_br || "", width_ratio: 0.14 },
                      { label: "Cooperativa/Cod. Beneficiario",
-                       value: (boleto.agencia_conta_boleto || "")
-                         .to_s.gsub(%r{\s+/\s+}, "/"),
+                       value: cooperativa_cod(boleto),
                        width_ratio: 0.35 }
                    ])
         end
@@ -392,21 +395,20 @@ module Brcobranca
         def desenha_linha_carteira(pdf, boleto)
           # Mostra apenas "carteira" quando a variacao e "01" (default comum),
           # ou "carteira/variacao" quando a variacao e explicitamente outra.
-          carteira_txt = if boleto.variacao && boleto.variacao.to_s != '01'
+          carteira_txt = if boleto.variacao && boleto.variacao.to_s != "01"
                            "#{boleto.carteira}/#{boleto.variacao}"
                          else
                            boleto.carteira.to_s
                          end
           draw_row(pdf, [
-                     { label: 'Uso do banco', value: '', width_ratio: 0.14 },
-                     { label: 'Carteira', value: carteira_txt, width_ratio: 0.22 },
-                     { label: 'Especie', value: boleto.especie.to_s, width_ratio: 0.08 },
-                     { label: 'Quantidade', value: boleto.quantidade.to_s, width_ratio: 0.07 },
+                     { label: "Uso do banco", value: "", width_ratio: 0.14 },
+                     { label: "Carteira", value: carteira_txt, width_ratio: 0.22 },
+                     { label: "Especie", value: boleto.especie.to_s, width_ratio: 0.08 },
+                     { label: "Quantidade", value: boleto.quantidade.to_s, width_ratio: 0.07 },
                      { label: "Valor",
-                       value: (boleto.valor.to_f.positive? ?
-                         boleto.valor.to_f.to_currency : ""),
+                       value: valor_formatado(boleto),
                        width_ratio: 0.14 },
-                     { label: 'Nosso numero', value: boleto.nosso_numero_boleto.to_s, width_ratio: 0.35 }
+                     { label: "Nosso numero", value: boleto.nosso_numero_boleto.to_s, width_ratio: 0.35 }
                    ])
         end
 
@@ -429,7 +431,7 @@ module Brcobranca
 
           # Label da coluna de instrucoes
           pdf.fill_color COR_TEXTO_LABEL
-          pdf.text_box 'Instrucoes (Texto de responsabilidade do beneficiario)',
+          pdf.text_box "Instrucoes (Texto de responsabilidade do beneficiario)",
                        at: [4, y - 3],
                        width: left_width - 8,
                        height: 8,
@@ -455,11 +457,11 @@ module Brcobranca
 
           # Coluna direita: 5 totalizadores empilhados
           totalizadores = [
-            ['(-) Desconto / Abatimento', boleto.descontos_e_abatimentos&.to_currency || ''],
-            ['(-) Outras deducoes', ''],
-            ['(+) Mora / Multa', ''],
-            ['(+) Outros Acrescimos', ''],
-            ['(=) Valor cobrado', '']
+            ["(-) Desconto / Abatimento", boleto.descontos_e_abatimentos&.to_currency || ""],
+            ["(-) Outras deducoes", ""],
+            ["(+) Mora / Multa", ""],
+            ["(+) Outros Acrescimos", ""],
+            ["(=) Valor cobrado", ""]
           ]
           totalizadores.each_with_index do |(label, valor), i|
             top = y - (i * TOTALIZADORES_HEIGHT)
@@ -494,10 +496,19 @@ module Brcobranca
         end
 
         def montar_instrucoes(boleto)
-          return boleto.instrucoes.to_s if boleto.instrucoes && !boleto.instrucoes.to_s.strip.empty?
+          if boleto.instrucoes &&
+             !boleto.instrucoes.to_s.strip.empty?
+            return boleto.instrucoes.to_s
+          end
 
-          [boleto.instrucao1, boleto.instrucao2, boleto.instrucao3,
-           boleto.instrucao4, boleto.instrucao5, boleto.instrucao6].compact.reject { |l| l.to_s.strip.empty? }.join("\n")
+          [
+            boleto.instrucao1, boleto.instrucao2,
+            boleto.instrucao3, boleto.instrucao4,
+            boleto.instrucao5, boleto.instrucao6,
+            boleto.instrucao7
+          ].compact.
+            reject { |l| l.to_s.strip.empty? }.
+            join("\n")
         end
 
         def desenha_linha_sacado(pdf, boleto)
@@ -510,7 +521,7 @@ module Brcobranca
           partes << boleto.sacado_endereco.to_s if boleto.sacado_endereco
 
           draw_row(pdf, [
-                     { label: 'Sacado', value: partes.join("\n"), width_ratio: 1.0, value_style: :bold, multiline: true }
+                     { label: "Sacado", value: partes.join("\n"), width_ratio: 1.0, value_style: :bold, multiline: true }
                    ], height: ROW_BENEF_HEIGHT)
         end
 
@@ -518,11 +529,11 @@ module Brcobranca
           avalista = if boleto.avalista && boleto.avalista_documento
                        "#{boleto.avalista} - #{boleto.avalista_documento}"
                      else
-                       ''
+                       ""
                      end
           draw_row(pdf, [
-                     { label: 'Sacador/Avalista', value: avalista, width_ratio: 0.80 },
-                     { label: 'Cod. baixa', value: '', width_ratio: 0.20 }
+                     { label: "Sacador/Avalista", value: avalista, width_ratio: 0.80 },
+                     { label: "Cod. baixa", value: "", width_ratio: 0.20 }
                    ], height: ROW_HEIGHT * 0.85)
         end
 
@@ -531,7 +542,7 @@ module Brcobranca
           y = pdf.cursor
           x_cursor = 0
 
-          # Faixa cinza clara na parte superior de cada celula (onde fica o label)
+          # Gray stripe on top of each cell (label area)
           # Da o efeito visual de "cabecalho de campo" caracteristico do boleto
           label_stripe_height = 10
           pdf.fill_color COR_FUNDO_LABEL
@@ -543,51 +554,66 @@ module Brcobranca
           pdf.stroke_rectangle([0, y], width, height)
 
           columns.each_with_index do |col, index|
-            col_width = (width * col[:width_ratio]).round(2)
-
-            # Destaque especial: fundo leve para campos destacados (ex.: Vencimento, Valor)
-            if col[:destaque]
-              pdf.fill_color COR_FUNDO_CABECALHO
-              pdf.fill_rectangle([x_cursor, y], col_width, height)
-              pdf.fill_color COR_TEXTO_VALOR
-              # Redesenha a faixa do label por cima do destaque
-              pdf.fill_color COR_FUNDO_LABEL
-              pdf.fill_rectangle([x_cursor, y], col_width, label_stripe_height)
-              pdf.fill_color COR_TEXTO_VALOR
+            col_w = (width * col[:width_ratio]).round(2)
+            draw_column(pdf, col, x_cursor, y,
+                        col_w, height, label_stripe_height)
+            unless index == columns.length - 1
+              pdf.stroke_vertical_line(
+                y, y - height, at: x_cursor + col_w
+              )
             end
-
-            # Label (topo, pequeno, cinza escuro)
-            pdf.fill_color COR_TEXTO_LABEL
-            pdf.text_box col[:label].to_s,
-                         at: [x_cursor + 4, y - 3],
-                         width: col_width - 8,
-                         height: 8,
-                         size: LABEL_SIZE,
-                         overflow: :shrink_to_fit
-            pdf.fill_color COR_TEXTO_VALOR
-
-            # Valor
-            align = col[:align] || :left
-            value_style = col[:value_style]
-            text_opts = {
-              at: [x_cursor + 4, y - 12],
-              width: col_width - 8,
-              height: height - 14,
-              size: VALUE_SIZE,
-              align: align,
-              overflow: :shrink_to_fit
-            }
-            text_opts[:style] = value_style if value_style
-
-            pdf.text_box col[:value].to_s, **text_opts
-
-            # Separador vertical entre colunas (exceto a ultima)
-            pdf.stroke_vertical_line y, y - height, at: x_cursor + col_width unless index == columns.length - 1
-
-            x_cursor += col_width
+            x_cursor += col_w
           end
 
           pdf.move_down height
+        end
+
+        def draw_column(pdf, col, pos_x, pos_y,
+                        col_width, height, stripe_h)
+          if col[:destaque]
+            draw_column_bg(pdf, pos_x, pos_y,
+                           col_width, height, stripe_h)
+          end
+
+          draw_column_label(pdf, col, pos_x, pos_y,
+                            col_width)
+          draw_column_value(pdf, col, pos_x, pos_y,
+                            col_width, height)
+        end
+
+        def draw_column_bg(pdf, pos_x, pos_y,
+                           col_width, height, stripe_h)
+          pdf.fill_color COR_FUNDO_CABECALHO
+          pdf.fill_rectangle([pos_x, pos_y], col_width, height)
+          pdf.fill_color COR_FUNDO_LABEL
+          pdf.fill_rectangle([pos_x, pos_y], col_width, stripe_h)
+          pdf.fill_color COR_TEXTO_VALOR
+        end
+
+        def draw_column_label(pdf, col, pos_x, pos_y,
+                              col_width)
+          pdf.fill_color COR_TEXTO_LABEL
+          pdf.text_box col[:label].to_s,
+                       at: [pos_x + 4, pos_y - 3],
+                       width: col_width - 8, height: 8,
+                       size: LABEL_SIZE,
+                       overflow: :shrink_to_fit
+          pdf.fill_color COR_TEXTO_VALOR
+        end
+
+        def draw_column_value(pdf, col, pos_x, pos_y,
+                              col_width, height)
+          opts = {
+            at: [pos_x + 4, pos_y - 12],
+            width: col_width - 8,
+            height: height - 14,
+            size: VALUE_SIZE,
+            align: col[:align] || :left,
+            overflow: :shrink_to_fit
+          }
+          style = col[:value_style]
+          opts[:style] = style if style
+          pdf.text_box col[:value].to_s, **opts
         end
 
         def desenha_codigo_barras_e_pix(pdf, boleto)
@@ -607,7 +633,6 @@ module Brcobranca
 
           if tem_pix
             qr_x = direita_x
-            # Renderiza QR Code diretamente sem usar bounding_box (evita double-move)
             qrcode = RQRCode::QRCode.new(boleto.emv.to_s, level: :h)
             png = qrcode.as_png(size: 300, module_size: 6, border_modules: 1)
 
@@ -615,7 +640,6 @@ module Brcobranca
                       at: [qr_x, y_start],
                       width: QRCODE_SIZE
 
-            # Label "Pague com PIX" em verde, centralizado abaixo do QR Code
             pdf.fill_color COR_PIX
             pdf.text_box pix_label(boleto),
                          at: [qr_x, y_start - QRCODE_SIZE - 2],
@@ -624,31 +648,27 @@ module Brcobranca
                          size: 8,
                          align: :center,
                          style: :bold
-            pdf.fill_color COR_TEXTO_VALOR
 
-            # Autenticacao mecanica (direita do QR Code)
             autent_x = qr_x + QRCODE_SIZE + 10
             pdf.fill_color COR_TEXTO_LABEL
-            pdf.text_box 'Autenticacao mecanica - Ficha de Compensacao',
+            pdf.text_box "Autenticacao mecanica - Ficha de Compensacao",
                          at: [autent_x, y_start - 5],
                          width: width - autent_x,
                          height: 15,
                          size: 7,
                          align: :right,
                          valign: :top
-            pdf.fill_color COR_TEXTO_VALOR
           else
-            # Autenticacao mecanica (toda a direita)
             pdf.fill_color COR_TEXTO_LABEL
-            pdf.text_box 'Autenticacao mecanica - Ficha de Compensacao',
+            pdf.text_box "Autenticacao mecanica - Ficha de Compensacao",
                          at: [direita_x, y_start - 5],
                          width: width - direita_x,
                          height: 15,
                          size: 7,
                          align: :right,
                          valign: :top
-            pdf.fill_color COR_TEXTO_VALOR
           end
+          pdf.fill_color COR_TEXTO_VALOR
 
           pdf.move_down BARCODE_HEIGHT + 8
         end
@@ -658,6 +678,16 @@ module Brcobranca
 
           config_label = Brcobranca.configuration.respond_to?(:pix_label) ? Brcobranca.configuration.pix_label : nil
           config_label || "Pague com PIX"
+        end
+
+        def valor_formatado(boleto)
+          v = boleto.valor.to_f
+          v.positive? ? v.to_currency : ""
+        end
+
+        def cooperativa_cod(boleto)
+          (boleto.agencia_conta_boleto || "").
+            to_s.gsub(%r{\s+/\s+}, "/")
         end
 
         def emv_valido?(emv)

--- a/lib/brcobranca/boleto/template/prawn_bolepix.rb
+++ b/lib/brcobranca/boleto/template/prawn_bolepix.rb
@@ -1,0 +1,650 @@
+# frozen_string_literal: true
+
+# Template alternativo para geração de boletos híbridos (com PIX) usando Prawn.
+#
+# Layout espelhado do padrão FEBRABAN observado em boletos SICOOB e demais bancos,
+# com:
+#   - Topo: Logo | Código do banco | Linha digitável
+#   - Local de pagamento | Vencimento
+#   - Beneficiário (com endereço) | Valor do Documento
+#   - Data Doc | Nº Doc | Espécie | Aceite | Data Processamento | Cooperativa/Cód. Beneficiário
+#   - Uso do banco | Carteira | Espécie | Quantidade | Valor | Nosso Número
+#   - Instruções (coluna esquerda) + Totalizadores empilhados (coluna direita)
+#   - Sacado (nome + endereço)
+#   - Sacador/Avalista | Cód. Baixa
+#   - Código de barras + [QR Code PIX se aplicável] + Autenticação mecânica
+#
+# Requer as gems: prawn, prawn-table, barby, rqrcode, chunky_png.
+module Brcobranca
+  module Boleto
+    module Template
+      # Indica se as gems necessárias para este template estão disponíveis.
+      begin
+        require 'prawn'
+        require 'prawn/measurement_extensions'
+        require 'prawn/table'
+        require 'barby'
+        require 'barby/barcode/code_25_interleaved'
+        require 'barby/outputter/prawn_outputter'
+        require 'rqrcode'
+        require 'chunky_png'
+        PRAWN_AVAILABLE = true
+      rescue LoadError
+        PRAWN_AVAILABLE = false
+      end
+
+      # Template Prawn para boletos híbridos com PIX - layout FEBRABAN.
+      module PrawnBolepix
+        extend self
+
+        PAGE_MARGIN = 25
+        LABEL_SIZE = 6
+        VALUE_SIZE = 9
+        LINHA_DIG_SIZE = 13
+        CODIGO_BANCO_SIZE = 15
+        HEADER_HEIGHT = 28
+        ROW_HEIGHT = 22
+        ROW_BENEF_HEIGHT = 34
+        TOTALIZADORES_HEIGHT = 16
+        # Altura do bloco suporta 7 linhas de 11pt = 77pt, + margem = ~80pt
+        # Isso é igual a 5 totalizadores de 16pt = 80pt (permite alinhamento perfeito)
+        BLOCO_INSTRUCOES_ALTURA = TOTALIZADORES_HEIGHT * 5
+        INSTRUCOES_LINHA_ALTURA = 10
+        INSTRUCOES_LINHAS_MAX = 7
+        BARCODE_HEIGHT = 48
+        QRCODE_SIZE = 85
+
+        # ==================== CORES ====================
+        # Cinza muito claro para fundos de cabeçalhos/labels
+        COR_FUNDO_LABEL = 'F5F5F5'
+        # Cinza claro para cabeçalho principal (barra de topo)
+        COR_FUNDO_CABECALHO = 'EEEEEE'
+        # Cinza para texto de labels
+        COR_TEXTO_LABEL = '555555'
+        # Preto para valores
+        COR_TEXTO_VALOR = '000000'
+        # Cinza para bordas
+        COR_BORDA = '333333'
+        # Verde escuro (tipo Sicoob) para destaque do PIX
+        COR_PIX = '006B3F'
+
+        def to(formato, _options = {})
+          raise 'Prawn não está disponível. Instale: gem install prawn prawn-table barby rqrcode chunky_png' unless PRAWN_AVAILABLE
+          raise ArgumentError, "Formato #{formato} não suportado pelo PrawnBolepix (apenas :pdf)" unless formato.to_sym == :pdf
+
+          render_boleto(self)
+        end
+
+        def lote(boletos, _options = {})
+          raise 'Prawn não está disponível.' unless PRAWN_AVAILABLE
+
+          render_boletos(boletos)
+        end
+
+        def method_missing(m, *args)
+          method = m.to_s
+          return to(:pdf, args.first || {}) if method == 'to_pdf'
+
+          super
+        end
+
+        def respond_to_missing?(method_name, include_private = false)
+          method_name.to_s == 'to_pdf' || super
+        end
+
+        private
+
+        def render_boleto(boleto)
+          pdf = new_document
+          draw_boleto(pdf, boleto)
+          pdf.render
+        end
+
+        def render_boletos(boletos)
+          pdf = new_document
+          boletos.each_with_index do |boleto, index|
+            draw_boleto(pdf, boleto)
+            pdf.start_new_page unless index == boletos.length - 1
+          end
+          pdf.render
+        end
+
+        def new_document
+          Prawn::Document.new(
+            page_size: 'A4',
+            margin: [PAGE_MARGIN, PAGE_MARGIN, PAGE_MARGIN, PAGE_MARGIN],
+            info: {
+              Title: 'Boleto Bancário (Bolepix)',
+              Creator: 'brcobranca',
+              Producer: 'Prawn + RQRCode + Barby'
+            }
+          )
+        end
+
+        def draw_boleto(pdf, boleto)
+          # 1) Recibo do Pagador (topo, versão compacta sem código de barras)
+          desenha_recibo_pagador(pdf, boleto)
+
+          # 2) Linha de corte pontilhada
+          desenha_linha_corte(pdf)
+
+          # 3) Ficha de Compensação (abaixo, versão completa com código de barras + PIX)
+          desenha_ficha_compensacao(pdf, boleto)
+        end
+
+        # =================================================================
+        # RECIBO DO PAGADOR (parte superior do boleto)
+        # =================================================================
+        # Layout simplificado, sem "Local de pagamento" e sem código de barras.
+        # Contém: topo, beneficiário, dados do documento, carteira, sacado,
+        # instruções reduzidas e autenticação mecânica (Recibo do Pagador).
+        def desenha_recibo_pagador(pdf, boleto)
+          desenha_topo(pdf, boleto, titulo_direito: 'Recibo do Pagador')
+          desenha_linha_beneficiario(pdf, boleto)
+          desenha_linha_documento(pdf, boleto)
+          desenha_linha_carteira(pdf, boleto)
+          desenha_linha_totalizadores_recibo(pdf, boleto)
+          desenha_linha_sacado(pdf, boleto)
+          desenha_linha_autenticacao_recibo(pdf)
+        end
+
+        # Linha pontilhada de corte entre o Recibo do Pagador e a Ficha de
+        # Compensação. Inclui um pequeno texto "Corte aqui" no canto.
+        def desenha_linha_corte(pdf)
+          pdf.move_down 6
+          y = pdf.cursor
+          width = pdf.bounds.width
+
+          pdf.stroke_color COR_TEXTO_LABEL
+          pdf.line_width 0.5
+          pdf.dash(2, space: 2)
+          pdf.stroke_horizontal_line 0, width, at: y
+          pdf.undash
+
+          # Texto "Corte aqui"
+          pdf.fill_color COR_TEXTO_LABEL
+          pdf.text_box 'Corte aqui --->',
+                       at: [width - 60, y + 3],
+                       width: 60,
+                       height: 8,
+                       size: 6,
+                       align: :right
+          pdf.fill_color COR_TEXTO_VALOR
+
+          pdf.stroke_color COR_BORDA
+          pdf.move_down 6
+        end
+
+        # Ficha de Compensação (a parte do boleto que é realmente paga).
+        def desenha_ficha_compensacao(pdf, boleto)
+          desenha_topo(pdf, boleto)
+          desenha_linha_local_pagamento(pdf, boleto)
+          desenha_linha_beneficiario(pdf, boleto)
+          desenha_linha_documento(pdf, boleto)
+          desenha_linha_carteira(pdf, boleto)
+          desenha_bloco_instrucoes_totalizadores(pdf, boleto)
+          desenha_linha_sacado(pdf, boleto)
+          desenha_linha_sacador_avalista(pdf, boleto)
+          desenha_codigo_barras_e_pix(pdf, boleto)
+        end
+
+        # Linha única de 5 totalizadores lado-a-lado (para o recibo, mais compacto)
+        def desenha_linha_totalizadores_recibo(pdf, boleto)
+          draw_row(pdf, [
+                     { label: '(-) Desconto / Abatimento', value: boleto.descontos_e_abatimentos&.to_currency || '', width_ratio: 0.20, align: :right },
+                     { label: '(-) Outras deduções', value: '', width_ratio: 0.20, align: :right },
+                     { label: '(+) Mora / Multa', value: '', width_ratio: 0.20, align: :right },
+                     { label: '(+) Outros Acréscimos', value: '', width_ratio: 0.20, align: :right },
+                     { label: '(=) Valor cobrado', value: '', width_ratio: 0.20, align: :right }
+                   ])
+        end
+
+        # Linha de autenticação mecânica do recibo (no canto direito).
+        def desenha_linha_autenticacao_recibo(pdf)
+          y = pdf.cursor
+          width = pdf.bounds.width
+          altura = ROW_HEIGHT * 0.85
+
+          pdf.stroke_color COR_BORDA
+          pdf.stroke_rectangle([0, y], width, altura)
+
+          pdf.fill_color COR_TEXTO_LABEL
+          pdf.text_box 'Autenticação mecânica - Recibo do Pagador',
+                       at: [4, y - 4],
+                       width: width - 8,
+                       height: altura - 4,
+                       size: 7,
+                       align: :right,
+                       valign: :top
+          pdf.fill_color COR_TEXTO_VALOR
+
+          pdf.move_down altura
+        end
+
+        # Desenha o topo do boleto: Logo | Código banco-DV | Linha digitável.
+        #
+        # @param titulo_direito [String, nil] Texto pequeno acima da linha
+        #   digitável (ex: "Recibo do Pagador"). Útil para diferenciar recibo
+        #   da ficha de compensação.
+        def desenha_topo(pdf, boleto, titulo_direito: nil)
+          width = pdf.bounds.width
+          y_topo = pdf.cursor
+
+          # Se houver título (ex: "Recibo do Pagador"), reserva 10pt acima para ele
+          if titulo_direito
+            pdf.fill_color COR_TEXTO_LABEL
+            pdf.text_box titulo_direito,
+                         at: [0, y_topo - 1],
+                         width: width - 4,
+                         height: 9,
+                         size: 7,
+                         align: :right,
+                         style: :italic
+            pdf.fill_color COR_TEXTO_VALOR
+            pdf.move_down 10
+          end
+
+          y = pdf.cursor
+          logo_w = 80
+          codigo_w = 55
+
+          pdf.stroke_color COR_BORDA
+          pdf.line_width 0.5
+
+          # Fundo sombreado no topo (cinza claro)
+          pdf.fill_color COR_FUNDO_CABECALHO
+          pdf.fill_rectangle([0, y], width, HEADER_HEIGHT)
+          pdf.fill_color COR_TEXTO_VALOR
+
+          # Logo do banco (se houver PNG) ou texto como fallback
+          desenha_logo_banco(pdf, boleto, 0, y, logo_w, HEADER_HEIGHT)
+
+          # Código do banco - DV (centro, destaque)
+          pdf.fill_color 'FFFFFF'
+          pdf.fill_rectangle([logo_w, y], codigo_w, HEADER_HEIGHT)
+          pdf.fill_color COR_TEXTO_VALOR
+
+          pdf.text_box "#{boleto.banco}-#{boleto.banco_dv}",
+                       at: [logo_w, y - 4],
+                       width: codigo_w,
+                       height: HEADER_HEIGHT,
+                       size: CODIGO_BANCO_SIZE,
+                       align: :center,
+                       valign: :center,
+                       style: :bold
+
+          # Linha digitável (direita, fundo branco)
+          pdf.fill_color 'FFFFFF'
+          pdf.fill_rectangle([logo_w + codigo_w, y], width - logo_w - codigo_w, HEADER_HEIGHT)
+          pdf.fill_color COR_TEXTO_VALOR
+
+          pdf.text_box boleto.codigo_barras.linha_digitavel,
+                       at: [logo_w + codigo_w + 5, y - 4],
+                       width: width - logo_w - codigo_w - 10,
+                       height: HEADER_HEIGHT,
+                       size: LINHA_DIG_SIZE,
+                       align: :right,
+                       valign: :center,
+                       style: :bold
+
+          # Bordas verticais internas
+          pdf.stroke_color COR_BORDA
+          pdf.stroke_vertical_line y, y - HEADER_HEIGHT, at: logo_w
+          pdf.stroke_vertical_line y, y - HEADER_HEIGHT, at: logo_w + codigo_w
+
+          # Borda inferior grossa (destaca o header)
+          pdf.line_width 1.2
+          pdf.stroke_horizontal_line 0, width, at: y - HEADER_HEIGHT
+          pdf.line_width 0.5
+
+          pdf.move_down HEADER_HEIGHT
+        end
+
+        def desenha_logo_banco(pdf, boleto, x, y, col_width, altura)
+          png_path = boleto.logotipo.sub(/\.eps\z/, '.png')
+          if File.exist?(png_path)
+            pdf.image png_path, at: [x + 2, y - 2], height: altura - 6, width: col_width - 4
+          else
+            pdf.text_box nome_banco_para_logo(boleto),
+                         at: [x, y - 6],
+                         width: col_width,
+                         height: altura,
+                         size: 8,
+                         align: :center,
+                         valign: :center,
+                         style: :bold
+          end
+        rescue StandardError
+          pdf.text_box nome_banco_para_logo(boleto),
+                       at: [x, y - 6],
+                       width: col_width,
+                       height: altura,
+                       size: 8,
+                       align: :center,
+                       valign: :center,
+                       style: :bold
+        end
+
+        # Nome do banco para fallback do logo (quando não há PNG).
+        def nome_banco_para_logo(boleto)
+          if boleto.respond_to?(:banco_nome) && boleto.banco_nome
+            boleto.banco_nome.to_s.upcase
+          else
+            boleto.class.to_s.split('::').last.upcase
+          end
+        end
+
+        def desenha_linha_local_pagamento(pdf, boleto)
+          draw_row(pdf, [
+                     { label: 'Local de pagamento', value: boleto.local_pagamento.to_s, width_ratio: 0.75, value_style: :bold },
+                     { label: 'Vencimento', value: boleto.data_vencimento.to_s_br, width_ratio: 0.25, value_style: :bold, destaque: true }
+                   ])
+        end
+
+        def desenha_linha_beneficiario(pdf, boleto)
+          benef_texto = montar_beneficiario(boleto)
+          draw_row(pdf, [
+                     { label: 'Beneficiário', value: benef_texto, width_ratio: 0.75, value_style: :bold, multiline: true },
+                     { label: 'Valor do Documento', value: boleto.valor_documento.to_currency, width_ratio: 0.25, value_style: :bold, destaque: true }
+                   ], height: ROW_BENEF_HEIGHT)
+        end
+
+        def montar_beneficiario(boleto)
+          partes = []
+          if boleto.cedente && boleto.documento_cedente
+            partes << "#{boleto.cedente} - CNPJ/CPF: #{boleto.documento_cedente.to_s.formata_documento}"
+          elsif boleto.cedente
+            partes << boleto.cedente
+          end
+          partes << boleto.cedente_endereco.to_s if boleto.cedente_endereco
+          partes.join("\n")
+        end
+
+        def desenha_linha_documento(pdf, boleto)
+          draw_row(pdf, [
+                     { label: 'Data do documento', value: boleto.data_documento&.to_s_br || '', width_ratio: 0.14 },
+                     { label: 'N. do Documento', value: boleto.documento_numero.to_s, width_ratio: 0.22 },
+                     { label: 'Espécie', value: boleto.especie_documento.to_s, width_ratio: 0.08 },
+                     { label: 'Aceite', value: boleto.aceite.to_s, width_ratio: 0.07 },
+                     { label: 'Data Processamento', value: boleto.data_processamento&.to_s_br || '', width_ratio: 0.14 },
+                     { label: 'Cooperativa contratante/Cód. Beneficiário', value: (boleto.agencia_conta_boleto || '').to_s.gsub(/\s+\/\s+/, '/'), width_ratio: 0.35 }
+                   ])
+        end
+
+        def desenha_linha_carteira(pdf, boleto)
+          # Mostra apenas "carteira" quando a variacao é "01" (default comum),
+          # ou "carteira/variacao" quando a variacao é explicitamente outra.
+          carteira_txt = if boleto.variacao && boleto.variacao.to_s != '01'
+                           "#{boleto.carteira}/#{boleto.variacao}"
+                         else
+                           boleto.carteira.to_s
+                         end
+          draw_row(pdf, [
+                     { label: 'Uso do banco', value: '', width_ratio: 0.14 },
+                     { label: 'Carteira', value: carteira_txt, width_ratio: 0.22 },
+                     { label: 'Espécie', value: boleto.especie.to_s, width_ratio: 0.08 },
+                     { label: 'Quantidade', value: boleto.quantidade.to_s, width_ratio: 0.07 },
+                     { label: 'Valor', value: (boleto.valor.to_f.positive? ? boleto.valor.to_f.to_currency : ''), width_ratio: 0.14 },
+                     { label: 'Nosso número', value: boleto.nosso_numero_boleto.to_s, width_ratio: 0.35 }
+                   ])
+        end
+
+        def desenha_bloco_instrucoes_totalizadores(pdf, boleto)
+          width = pdf.bounds.width
+          y = pdf.cursor
+          left_width = width * 0.65
+          right_width = width * 0.35
+          altura = BLOCO_INSTRUCOES_ALTURA
+
+          # Faixa cinza clara no topo (label)
+          label_stripe_height = 10
+          pdf.fill_color COR_FUNDO_LABEL
+          pdf.fill_rectangle([0, y], left_width, label_stripe_height)
+          pdf.fill_color COR_TEXTO_VALOR
+
+          # Borda externa do bloco
+          pdf.stroke_color COR_BORDA
+          pdf.stroke_rectangle([0, y], width, altura)
+
+          # Label da coluna de instruções
+          pdf.fill_color COR_TEXTO_LABEL
+          pdf.text_box 'Instruções (Texto de responsabilidade do beneficiário)',
+                       at: [4, y - 3],
+                       width: left_width - 8,
+                       height: 8,
+                       size: LABEL_SIZE
+          pdf.fill_color COR_TEXTO_VALOR
+
+          # Área de instruções: suporta até INSTRUCOES_LINHAS_MAX (7) linhas de texto
+          instrucoes = montar_instrucoes(boleto)
+          area_instrucoes_altura = INSTRUCOES_LINHA_ALTURA * INSTRUCOES_LINHAS_MAX
+          # Garante que a área não exceda o bloco
+          area_instrucoes_altura = [area_instrucoes_altura, altura - 14].min
+
+          pdf.text_box instrucoes,
+                       at: [4, y - 12],
+                       width: left_width - 8,
+                       height: area_instrucoes_altura,
+                       size: VALUE_SIZE,
+                       leading: 1,
+                       overflow: :shrink_to_fit
+
+          # Separador vertical entre colunas
+          pdf.stroke_vertical_line y, y - altura, at: left_width
+
+          # Coluna direita: 5 totalizadores empilhados
+          totalizadores = [
+            ['(-) Desconto / Abatimento', boleto.descontos_e_abatimentos&.to_currency || ''],
+            ['(-) Outras deduções', ''],
+            ['(+) Mora / Multa', ''],
+            ['(+) Outros Acréscimos', ''],
+            ['(=) Valor cobrado', '']
+          ]
+          totalizadores.each_with_index do |(label, valor), i|
+            top = y - (i * TOTALIZADORES_HEIGHT)
+
+            # Faixa cinza clara de label
+            pdf.fill_color COR_FUNDO_LABEL
+            pdf.fill_rectangle([left_width, top], right_width, label_stripe_height)
+            pdf.fill_color COR_TEXTO_VALOR
+
+            # Label (esquerda, pequeno)
+            pdf.fill_color COR_TEXTO_LABEL
+            pdf.text_box label,
+                         at: [left_width + 4, top - 3],
+                         width: right_width - 8,
+                         height: 8,
+                         size: LABEL_SIZE
+            pdf.fill_color COR_TEXTO_VALOR
+
+            # Valor (alinhado à direita)
+            pdf.text_box valor,
+                         at: [left_width + 4, top - 12],
+                         width: right_width - 8,
+                         height: 9,
+                         size: VALUE_SIZE,
+                         align: :right
+
+            # Separador horizontal entre totalizadores (exceto último)
+            pdf.stroke_horizontal_line left_width, width, at: top - TOTALIZADORES_HEIGHT if i < totalizadores.length - 1
+          end
+
+          pdf.move_down altura
+        end
+
+        def montar_instrucoes(boleto)
+          return boleto.instrucoes.to_s if boleto.instrucoes && !boleto.instrucoes.to_s.strip.empty?
+
+          [boleto.instrucao1, boleto.instrucao2, boleto.instrucao3,
+           boleto.instrucao4, boleto.instrucao5, boleto.instrucao6].compact.reject { |l| l.to_s.strip.empty? }.join("\n")
+        end
+
+        def desenha_linha_sacado(pdf, boleto)
+          partes = []
+          if boleto.sacado && boleto.sacado_documento
+            partes << "#{boleto.sacado} - #{boleto.sacado_documento.to_s.formata_documento}"
+          elsif boleto.sacado
+            partes << boleto.sacado
+          end
+          partes << boleto.sacado_endereco.to_s if boleto.sacado_endereco
+
+          draw_row(pdf, [
+                     { label: 'Sacado', value: partes.join("\n"), width_ratio: 1.0, value_style: :bold, multiline: true }
+                   ], height: ROW_BENEF_HEIGHT)
+        end
+
+        def desenha_linha_sacador_avalista(pdf, boleto)
+          avalista = if boleto.avalista && boleto.avalista_documento
+                       "#{boleto.avalista} - #{boleto.avalista_documento}"
+                     else
+                       ''
+                     end
+          draw_row(pdf, [
+                     { label: 'Sacador/Avalista', value: avalista, width_ratio: 0.80 },
+                     { label: 'Cód. baixa', value: '', width_ratio: 0.20 }
+                   ], height: ROW_HEIGHT * 0.85)
+        end
+
+        def draw_row(pdf, columns, height: ROW_HEIGHT)
+          width = pdf.bounds.width
+          y = pdf.cursor
+          x_cursor = 0
+
+          # Faixa cinza clara na parte superior de cada célula (onde fica o label)
+          # Dá o efeito visual de "cabeçalho de campo" característico do boleto
+          label_stripe_height = 10
+          pdf.fill_color COR_FUNDO_LABEL
+          pdf.fill_rectangle([0, y], width, label_stripe_height)
+          pdf.fill_color COR_TEXTO_VALOR
+
+          # Borda externa do retângulo
+          pdf.stroke_color COR_BORDA
+          pdf.stroke_rectangle([0, y], width, height)
+
+          columns.each_with_index do |col, index|
+            col_width = (width * col[:width_ratio]).round(2)
+
+            # Destaque especial: fundo leve para campos destacados (ex.: Vencimento, Valor)
+            if col[:destaque]
+              pdf.fill_color COR_FUNDO_CABECALHO
+              pdf.fill_rectangle([x_cursor, y], col_width, height)
+              pdf.fill_color COR_TEXTO_VALOR
+              # Redesenha a faixa do label por cima do destaque
+              pdf.fill_color COR_FUNDO_LABEL
+              pdf.fill_rectangle([x_cursor, y], col_width, label_stripe_height)
+              pdf.fill_color COR_TEXTO_VALOR
+            end
+
+            # Label (topo, pequeno, cinza escuro)
+            pdf.fill_color COR_TEXTO_LABEL
+            pdf.text_box col[:label].to_s,
+                         at: [x_cursor + 4, y - 3],
+                         width: col_width - 8,
+                         height: 8,
+                         size: LABEL_SIZE,
+                         overflow: :shrink_to_fit
+            pdf.fill_color COR_TEXTO_VALOR
+
+            # Valor
+            align = col[:align] || :left
+            value_style = col[:value_style]
+            text_opts = {
+              at: [x_cursor + 4, y - 12],
+              width: col_width - 8,
+              height: height - 14,
+              size: VALUE_SIZE,
+              align: align,
+              overflow: :shrink_to_fit
+            }
+            text_opts[:style] = value_style if value_style
+
+            pdf.text_box col[:value].to_s, **text_opts
+
+            # Separador vertical entre colunas (exceto a última)
+            pdf.stroke_vertical_line y, y - height, at: x_cursor + col_width unless index == columns.length - 1
+
+            x_cursor += col_width
+          end
+
+          pdf.move_down height
+        end
+
+        def desenha_codigo_barras_e_pix(pdf, boleto)
+          return unless boleto.codigo_barras
+
+          width = pdf.bounds.width
+          y_start = pdf.cursor
+          tem_pix = boleto.emv && emv_valido?(boleto.emv)
+
+          barras_width = tem_pix ? width * 0.55 : width * 0.60
+          direita_x = barras_width + 10
+
+          pdf.bounding_box([0, y_start], width: barras_width, height: BARCODE_HEIGHT) do
+            barcode = Barby::Code25Interleaved.new(boleto.codigo_barras.to_s)
+            barcode.annotate_pdf(pdf, height: BARCODE_HEIGHT - 5, xdim: 0.9)
+          end
+
+          if tem_pix
+            qr_x = direita_x
+            # Renderiza QR Code diretamente sem usar bounding_box (evita double-move)
+            qrcode = RQRCode::QRCode.new(boleto.emv.to_s, level: :h)
+            png = qrcode.as_png(size: 300, module_size: 6, border_modules: 1)
+
+            pdf.image StringIO.new(png.to_s),
+                      at: [qr_x, y_start],
+                      width: QRCODE_SIZE
+
+            # Label "Pague com PIX" em verde, centralizado abaixo do QR Code
+            pdf.fill_color COR_PIX
+            pdf.text_box pix_label(boleto),
+                         at: [qr_x, y_start - QRCODE_SIZE - 2],
+                         width: QRCODE_SIZE,
+                         height: 10,
+                         size: 8,
+                         align: :center,
+                         style: :bold
+            pdf.fill_color COR_TEXTO_VALOR
+
+            # Autenticação mecânica (direita do QR Code)
+            autent_x = qr_x + QRCODE_SIZE + 10
+            pdf.fill_color COR_TEXTO_LABEL
+            pdf.text_box 'Autenticação mecânica - Ficha de Compensação',
+                         at: [autent_x, y_start - 5],
+                         width: width - autent_x,
+                         height: 15,
+                         size: 7,
+                         align: :right,
+                         valign: :top
+            pdf.fill_color COR_TEXTO_VALOR
+          else
+            # Autenticação mecânica (toda a direita)
+            pdf.fill_color COR_TEXTO_LABEL
+            pdf.text_box 'Autenticação mecânica - Ficha de Compensação',
+                         at: [direita_x, y_start - 5],
+                         width: width - direita_x,
+                         height: 15,
+                         size: 7,
+                         align: :right,
+                         valign: :top
+            pdf.fill_color COR_TEXTO_VALOR
+          end
+
+          pdf.move_down BARCODE_HEIGHT + 8
+        end
+
+        def pix_label(boleto)
+          return boleto.pix_label if boleto.respond_to?(:pix_label) && boleto.pix_label
+
+          config_label = Brcobranca.configuration.respond_to?(:pix_label) ? Brcobranca.configuration.pix_label : nil
+          config_label || 'Pague com PIX'
+        end
+
+        def emv_valido?(emv)
+          return false if emv.nil? || emv.to_s.strip.empty?
+
+          emv.to_s.start_with?('0002')
+        end
+      end
+    end
+  end
+end

--- a/lib/brcobranca/boleto/template/prawn_bolepix.rb
+++ b/lib/brcobranca/boleto/template/prawn_bolepix.rb
@@ -1,39 +1,40 @@
 # frozen_string_literal: true
 
-# Template alternativo para geração de boletos híbridos (com PIX) usando Prawn.
+# Template alternativo para geracao de boletos hibridos (com PIX) usando Prawn.
 #
-# Layout espelhado do padrão FEBRABAN observado em boletos SICOOB e demais bancos,
+# Layout espelhado do padrao FEBRABAN observado em boletos SICOOB e demais bancos,
 # com:
-#   - Topo: Logo | Código do banco | Linha digitável
+#   - Topo: Logo | Codigo do banco | Linha digitavel
 #   - Local de pagamento | Vencimento
-#   - Beneficiário (com endereço) | Valor do Documento
-#   - Data Doc | Nº Doc | Espécie | Aceite | Data Processamento | Cooperativa/Cód. Beneficiário
-#   - Uso do banco | Carteira | Espécie | Quantidade | Valor | Nosso Número
-#   - Instruções (coluna esquerda) + Totalizadores empilhados (coluna direita)
-#   - Sacado (nome + endereço)
-#   - Sacador/Avalista | Cód. Baixa
-#   - Código de barras + [QR Code PIX se aplicável] + Autenticação mecânica
+#   - Beneficiario (com endereco) | Valor do Documento
+#   - Data Doc | No. Doc | Especie | Aceite | Data Processamento | Cooperativa/Cod. Beneficiario
+#   - Uso do banco | Carteira | Especie | Quantidade | Valor | Nosso Numero
+#   - Instrucoes (coluna esquerda) + Totalizadores empilhados (coluna direita)
+#   - Sacado (nome + endereco)
+#   - Sacador/Avalista | Cod. Baixa
+#   - Codigo de barras + [QR Code PIX se aplicavel] + Autenticacao mecanica
 #
 # Requer as gems: prawn, prawn-table, barby, rqrcode, chunky_png.
 module Brcobranca
   module Boleto
     module Template
-      # Indica se as gems necessárias para este template estão disponíveis.
+      # Indica se as gems necessarias para este template estao disponiveis.
       begin
-        require 'prawn'
-        require 'prawn/measurement_extensions'
-        require 'prawn/table'
-        require 'barby'
-        require 'barby/barcode/code_25_interleaved'
-        require 'barby/outputter/prawn_outputter'
-        require 'rqrcode'
-        require 'chunky_png'
+        require "prawn"
+        require "prawn/measurement_extensions"
+        require "prawn/table"
+        require "barby"
+        require "barby/barcode/code_25_interleaved"
+        require "barby/outputter/prawn_outputter"
+        require "rqrcode"
+        require "chunky_png"
+        require "stringio"
         PRAWN_AVAILABLE = true
       rescue LoadError
         PRAWN_AVAILABLE = false
       end
 
-      # Template Prawn para boletos híbridos com PIX - layout FEBRABAN.
+      # Template Prawn para boletos hibridos com PIX - layout FEBRABAN.
       module PrawnBolepix
         extend self
 
@@ -47,7 +48,7 @@ module Brcobranca
         ROW_BENEF_HEIGHT = 34
         TOTALIZADORES_HEIGHT = 16
         # Altura do bloco suporta 7 linhas de 11pt = 77pt, + margem = ~80pt
-        # Isso é igual a 5 totalizadores de 16pt = 80pt (permite alinhamento perfeito)
+        # Isso e igual a 5 totalizadores de 16pt = 80pt (permite alinhamento perfeito)
         BLOCO_INSTRUCOES_ALTURA = TOTALIZADORES_HEIGHT * 5
         INSTRUCOES_LINHA_ALTURA = 10
         INSTRUCOES_LINHAS_MAX = 7
@@ -55,9 +56,9 @@ module Brcobranca
         QRCODE_SIZE = 85
 
         # ==================== CORES ====================
-        # Cinza muito claro para fundos de cabeçalhos/labels
+        # Cinza muito claro para fundos de cabecalhos/labels
         COR_FUNDO_LABEL = 'F5F5F5'
-        # Cinza claro para cabeçalho principal (barra de topo)
+        # Cinza claro para cabecalho principal (barra de topo)
         COR_FUNDO_CABECALHO = 'EEEEEE'
         # Cinza para texto de labels
         COR_TEXTO_LABEL = '555555'
@@ -69,27 +70,25 @@ module Brcobranca
         COR_PIX = '006B3F'
 
         def to(formato, _options = {})
-          raise 'Prawn não está disponível. Instale: gem install prawn prawn-table barby rqrcode chunky_png' unless PRAWN_AVAILABLE
-          raise ArgumentError, "Formato #{formato} não suportado pelo PrawnBolepix (apenas :pdf)" unless formato.to_sym == :pdf
+          unless PRAWN_AVAILABLE
+            raise "Prawn nao esta disponivel. Instale: " \
+                  "gem install prawn prawn-table barby rqrcode chunky_png"
+          end
+          unless formato.to_sym == :pdf
+            raise ArgumentError, "Formato #{formato} nao suportado (apenas :pdf)"
+          end
 
           render_boleto(self)
         end
 
         def lote(boletos, _options = {})
-          raise 'Prawn não está disponível.' unless PRAWN_AVAILABLE
+          raise "Prawn nao esta disponivel." unless PRAWN_AVAILABLE
 
           render_boletos(boletos)
         end
 
-        def method_missing(m, *args)
-          method = m.to_s
-          return to(:pdf, args.first || {}) if method == 'to_pdf'
-
-          super
-        end
-
-        def respond_to_missing?(method_name, include_private = false)
-          method_name.to_s == 'to_pdf' || super
+        def to_pdf(options = {})
+          to(:pdf, options)
         end
 
         private
@@ -111,10 +110,10 @@ module Brcobranca
 
         def new_document
           Prawn::Document.new(
-            page_size: 'A4',
+            page_size: "A4",
             margin: [PAGE_MARGIN, PAGE_MARGIN, PAGE_MARGIN, PAGE_MARGIN],
             info: {
-              Title: 'Boleto Bancário (Bolepix)',
+              Title: 'Boleto Bancario (Bolepix)',
               Creator: 'brcobranca',
               Producer: 'Prawn + RQRCode + Barby'
             }
@@ -122,22 +121,22 @@ module Brcobranca
         end
 
         def draw_boleto(pdf, boleto)
-          # 1) Recibo do Pagador (topo, versão compacta sem código de barras)
+          # 1) Recibo do Pagador (topo, versao compacta sem codigo de barras)
           desenha_recibo_pagador(pdf, boleto)
 
           # 2) Linha de corte pontilhada
           desenha_linha_corte(pdf)
 
-          # 3) Ficha de Compensação (abaixo, versão completa com código de barras + PIX)
+          # 3) Ficha de Compensacao (abaixo, versao completa com codigo de barras + PIX)
           desenha_ficha_compensacao(pdf, boleto)
         end
 
         # =================================================================
         # RECIBO DO PAGADOR (parte superior do boleto)
         # =================================================================
-        # Layout simplificado, sem "Local de pagamento" e sem código de barras.
-        # Contém: topo, beneficiário, dados do documento, carteira, sacado,
-        # instruções reduzidas e autenticação mecânica (Recibo do Pagador).
+        # Layout simplificado, sem "Local de pagamento" e sem codigo de barras.
+        # Contem: topo, beneficiario, dados do documento, carteira, sacado,
+        # instrucoes reduzidas e autenticacao mecanica (Recibo do Pagador).
         def desenha_recibo_pagador(pdf, boleto)
           desenha_topo(pdf, boleto, titulo_direito: 'Recibo do Pagador')
           desenha_linha_beneficiario(pdf, boleto)
@@ -149,7 +148,7 @@ module Brcobranca
         end
 
         # Linha pontilhada de corte entre o Recibo do Pagador e a Ficha de
-        # Compensação. Inclui um pequeno texto "Corte aqui" no canto.
+        # Compensacao. Inclui um pequeno texto "Corte aqui" no canto.
         def desenha_linha_corte(pdf)
           pdf.move_down 6
           y = pdf.cursor
@@ -175,7 +174,7 @@ module Brcobranca
           pdf.move_down 6
         end
 
-        # Ficha de Compensação (a parte do boleto que é realmente paga).
+        # Ficha de Compensacao (a parte do boleto que e realmente paga).
         def desenha_ficha_compensacao(pdf, boleto)
           desenha_topo(pdf, boleto)
           desenha_linha_local_pagamento(pdf, boleto)
@@ -188,18 +187,24 @@ module Brcobranca
           desenha_codigo_barras_e_pix(pdf, boleto)
         end
 
-        # Linha única de 5 totalizadores lado-a-lado (para o recibo, mais compacto)
+        # Linha unica de 5 totalizadores lado-a-lado (para o recibo, mais compacto)
         def desenha_linha_totalizadores_recibo(pdf, boleto)
+          desconto = boleto.descontos_e_abatimentos&.to_currency || ""
           draw_row(pdf, [
-                     { label: '(-) Desconto / Abatimento', value: boleto.descontos_e_abatimentos&.to_currency || '', width_ratio: 0.20, align: :right },
-                     { label: '(-) Outras deduções', value: '', width_ratio: 0.20, align: :right },
-                     { label: '(+) Mora / Multa', value: '', width_ratio: 0.20, align: :right },
-                     { label: '(+) Outros Acréscimos', value: '', width_ratio: 0.20, align: :right },
-                     { label: '(=) Valor cobrado', value: '', width_ratio: 0.20, align: :right }
-                   ])
+            { label: "(-) Desconto / Abatimento", value: desconto,
+              width_ratio: 0.20, align: :right },
+            { label: "(-) Outras deducoes", value: "",
+              width_ratio: 0.20, align: :right },
+            { label: "(+) Mora / Multa", value: "",
+              width_ratio: 0.20, align: :right },
+            { label: "(+) Outros Acrescimos", value: "",
+              width_ratio: 0.20, align: :right },
+            { label: "(=) Valor cobrado", value: "",
+              width_ratio: 0.20, align: :right }
+          ])
         end
 
-        # Linha de autenticação mecânica do recibo (no canto direito).
+        # Linha de autenticacao mecanica do recibo (no canto direito).
         def desenha_linha_autenticacao_recibo(pdf)
           y = pdf.cursor
           width = pdf.bounds.width
@@ -209,7 +214,7 @@ module Brcobranca
           pdf.stroke_rectangle([0, y], width, altura)
 
           pdf.fill_color COR_TEXTO_LABEL
-          pdf.text_box 'Autenticação mecânica - Recibo do Pagador',
+          pdf.text_box 'Autenticacao mecanica - Recibo do Pagador',
                        at: [4, y - 4],
                        width: width - 8,
                        height: altura - 4,
@@ -221,16 +226,16 @@ module Brcobranca
           pdf.move_down altura
         end
 
-        # Desenha o topo do boleto: Logo | Código banco-DV | Linha digitável.
+        # Desenha o topo do boleto: Logo | Codigo banco-DV | Linha digitavel.
         #
         # @param titulo_direito [String, nil] Texto pequeno acima da linha
-        #   digitável (ex: "Recibo do Pagador"). Útil para diferenciar recibo
-        #   da ficha de compensação.
+        #   digitavel (ex: "Recibo do Pagador"). Util para diferenciar recibo
+        #   da ficha de compensacao.
         def desenha_topo(pdf, boleto, titulo_direito: nil)
           width = pdf.bounds.width
           y_topo = pdf.cursor
 
-          # Se houver título (ex: "Recibo do Pagador"), reserva 10pt acima para ele
+          # Se houver titulo (ex: "Recibo do Pagador"), reserva 10pt acima para ele
           if titulo_direito
             pdf.fill_color COR_TEXTO_LABEL
             pdf.text_box titulo_direito,
@@ -259,7 +264,7 @@ module Brcobranca
           # Logo do banco (se houver PNG) ou texto como fallback
           desenha_logo_banco(pdf, boleto, 0, y, logo_w, HEADER_HEIGHT)
 
-          # Código do banco - DV (centro, destaque)
+          # Codigo do banco - DV (centro, destaque)
           pdf.fill_color 'FFFFFF'
           pdf.fill_rectangle([logo_w, y], codigo_w, HEADER_HEIGHT)
           pdf.fill_color COR_TEXTO_VALOR
@@ -273,7 +278,7 @@ module Brcobranca
                        valign: :center,
                        style: :bold
 
-          # Linha digitável (direita, fundo branco)
+          # Linha digitavel (direita, fundo branco)
           pdf.fill_color 'FFFFFF'
           pdf.fill_rectangle([logo_w + codigo_w, y], width - logo_w - codigo_w, HEADER_HEIGHT)
           pdf.fill_color COR_TEXTO_VALOR
@@ -325,7 +330,7 @@ module Brcobranca
                        style: :bold
         end
 
-        # Nome do banco para fallback do logo (quando não há PNG).
+        # Nome do banco para fallback do logo (quando nao ha PNG).
         def nome_banco_para_logo(boleto)
           if boleto.respond_to?(:banco_nome) && boleto.banco_nome
             boleto.banco_nome.to_s.upcase
@@ -336,17 +341,27 @@ module Brcobranca
 
         def desenha_linha_local_pagamento(pdf, boleto)
           draw_row(pdf, [
-                     { label: 'Local de pagamento', value: boleto.local_pagamento.to_s, width_ratio: 0.75, value_style: :bold },
-                     { label: 'Vencimento', value: boleto.data_vencimento.to_s_br, width_ratio: 0.25, value_style: :bold, destaque: true }
-                   ])
+            { label: "Local de pagamento",
+              value: boleto.local_pagamento.to_s,
+              width_ratio: 0.75, value_style: :bold },
+            { label: "Vencimento",
+              value: boleto.data_vencimento.to_s_br,
+              width_ratio: 0.25, value_style: :bold,
+              destaque: true }
+          ])
         end
 
         def desenha_linha_beneficiario(pdf, boleto)
           benef_texto = montar_beneficiario(boleto)
           draw_row(pdf, [
-                     { label: 'Beneficiário', value: benef_texto, width_ratio: 0.75, value_style: :bold, multiline: true },
-                     { label: 'Valor do Documento', value: boleto.valor_documento.to_currency, width_ratio: 0.25, value_style: :bold, destaque: true }
-                   ], height: ROW_BENEF_HEIGHT)
+            { label: "Beneficiario", value: benef_texto,
+              width_ratio: 0.75, value_style: :bold,
+              multiline: true },
+            { label: "Valor do Documento",
+              value: boleto.valor_documento.to_currency,
+              width_ratio: 0.25, value_style: :bold,
+              destaque: true }
+          ], height: ROW_BENEF_HEIGHT)
         end
 
         def montar_beneficiario(boleto)
@@ -364,16 +379,19 @@ module Brcobranca
           draw_row(pdf, [
                      { label: 'Data do documento', value: boleto.data_documento&.to_s_br || '', width_ratio: 0.14 },
                      { label: 'N. do Documento', value: boleto.documento_numero.to_s, width_ratio: 0.22 },
-                     { label: 'Espécie', value: boleto.especie_documento.to_s, width_ratio: 0.08 },
+                     { label: 'Especie', value: boleto.especie_documento.to_s, width_ratio: 0.08 },
                      { label: 'Aceite', value: boleto.aceite.to_s, width_ratio: 0.07 },
                      { label: 'Data Processamento', value: boleto.data_processamento&.to_s_br || '', width_ratio: 0.14 },
-                     { label: 'Cooperativa contratante/Cód. Beneficiário', value: (boleto.agencia_conta_boleto || '').to_s.gsub(/\s+\/\s+/, '/'), width_ratio: 0.35 }
+                     { label: "Cooperativa/Cod. Beneficiario",
+                       value: (boleto.agencia_conta_boleto || "")
+                         .to_s.gsub(%r{\s+/\s+}, "/"),
+                       width_ratio: 0.35 }
                    ])
         end
 
         def desenha_linha_carteira(pdf, boleto)
-          # Mostra apenas "carteira" quando a variacao é "01" (default comum),
-          # ou "carteira/variacao" quando a variacao é explicitamente outra.
+          # Mostra apenas "carteira" quando a variacao e "01" (default comum),
+          # ou "carteira/variacao" quando a variacao e explicitamente outra.
           carteira_txt = if boleto.variacao && boleto.variacao.to_s != '01'
                            "#{boleto.carteira}/#{boleto.variacao}"
                          else
@@ -382,10 +400,13 @@ module Brcobranca
           draw_row(pdf, [
                      { label: 'Uso do banco', value: '', width_ratio: 0.14 },
                      { label: 'Carteira', value: carteira_txt, width_ratio: 0.22 },
-                     { label: 'Espécie', value: boleto.especie.to_s, width_ratio: 0.08 },
+                     { label: 'Especie', value: boleto.especie.to_s, width_ratio: 0.08 },
                      { label: 'Quantidade', value: boleto.quantidade.to_s, width_ratio: 0.07 },
-                     { label: 'Valor', value: (boleto.valor.to_f.positive? ? boleto.valor.to_f.to_currency : ''), width_ratio: 0.14 },
-                     { label: 'Nosso número', value: boleto.nosso_numero_boleto.to_s, width_ratio: 0.35 }
+                     { label: "Valor",
+                       value: (boleto.valor.to_f.positive? ?
+                         boleto.valor.to_f.to_currency : ""),
+                       width_ratio: 0.14 },
+                     { label: 'Nosso numero', value: boleto.nosso_numero_boleto.to_s, width_ratio: 0.35 }
                    ])
         end
 
@@ -406,19 +427,19 @@ module Brcobranca
           pdf.stroke_color COR_BORDA
           pdf.stroke_rectangle([0, y], width, altura)
 
-          # Label da coluna de instruções
+          # Label da coluna de instrucoes
           pdf.fill_color COR_TEXTO_LABEL
-          pdf.text_box 'Instruções (Texto de responsabilidade do beneficiário)',
+          pdf.text_box 'Instrucoes (Texto de responsabilidade do beneficiario)',
                        at: [4, y - 3],
                        width: left_width - 8,
                        height: 8,
                        size: LABEL_SIZE
           pdf.fill_color COR_TEXTO_VALOR
 
-          # Área de instruções: suporta até INSTRUCOES_LINHAS_MAX (7) linhas de texto
+          # Area de instrucoes: suporta ate INSTRUCOES_LINHAS_MAX (7) linhas de texto
           instrucoes = montar_instrucoes(boleto)
           area_instrucoes_altura = INSTRUCOES_LINHA_ALTURA * INSTRUCOES_LINHAS_MAX
-          # Garante que a área não exceda o bloco
+          # Garante que a area nao exceda o bloco
           area_instrucoes_altura = [area_instrucoes_altura, altura - 14].min
 
           pdf.text_box instrucoes,
@@ -435,9 +456,9 @@ module Brcobranca
           # Coluna direita: 5 totalizadores empilhados
           totalizadores = [
             ['(-) Desconto / Abatimento', boleto.descontos_e_abatimentos&.to_currency || ''],
-            ['(-) Outras deduções', ''],
+            ['(-) Outras deducoes', ''],
             ['(+) Mora / Multa', ''],
-            ['(+) Outros Acréscimos', ''],
+            ['(+) Outros Acrescimos', ''],
             ['(=) Valor cobrado', '']
           ]
           totalizadores.each_with_index do |(label, valor), i|
@@ -457,7 +478,7 @@ module Brcobranca
                          size: LABEL_SIZE
             pdf.fill_color COR_TEXTO_VALOR
 
-            # Valor (alinhado à direita)
+            # Valor (alinhado a direita)
             pdf.text_box valor,
                          at: [left_width + 4, top - 12],
                          width: right_width - 8,
@@ -465,7 +486,7 @@ module Brcobranca
                          size: VALUE_SIZE,
                          align: :right
 
-            # Separador horizontal entre totalizadores (exceto último)
+            # Separador horizontal entre totalizadores (exceto ultimo)
             pdf.stroke_horizontal_line left_width, width, at: top - TOTALIZADORES_HEIGHT if i < totalizadores.length - 1
           end
 
@@ -501,7 +522,7 @@ module Brcobranca
                      end
           draw_row(pdf, [
                      { label: 'Sacador/Avalista', value: avalista, width_ratio: 0.80 },
-                     { label: 'Cód. baixa', value: '', width_ratio: 0.20 }
+                     { label: 'Cod. baixa', value: '', width_ratio: 0.20 }
                    ], height: ROW_HEIGHT * 0.85)
         end
 
@@ -510,14 +531,14 @@ module Brcobranca
           y = pdf.cursor
           x_cursor = 0
 
-          # Faixa cinza clara na parte superior de cada célula (onde fica o label)
-          # Dá o efeito visual de "cabeçalho de campo" característico do boleto
+          # Faixa cinza clara na parte superior de cada celula (onde fica o label)
+          # Da o efeito visual de "cabecalho de campo" caracteristico do boleto
           label_stripe_height = 10
           pdf.fill_color COR_FUNDO_LABEL
           pdf.fill_rectangle([0, y], width, label_stripe_height)
           pdf.fill_color COR_TEXTO_VALOR
 
-          # Borda externa do retângulo
+          # Borda externa do retangulo
           pdf.stroke_color COR_BORDA
           pdf.stroke_rectangle([0, y], width, height)
 
@@ -560,7 +581,7 @@ module Brcobranca
 
             pdf.text_box col[:value].to_s, **text_opts
 
-            # Separador vertical entre colunas (exceto a última)
+            # Separador vertical entre colunas (exceto a ultima)
             pdf.stroke_vertical_line y, y - height, at: x_cursor + col_width unless index == columns.length - 1
 
             x_cursor += col_width
@@ -605,10 +626,10 @@ module Brcobranca
                          style: :bold
             pdf.fill_color COR_TEXTO_VALOR
 
-            # Autenticação mecânica (direita do QR Code)
+            # Autenticacao mecanica (direita do QR Code)
             autent_x = qr_x + QRCODE_SIZE + 10
             pdf.fill_color COR_TEXTO_LABEL
-            pdf.text_box 'Autenticação mecânica - Ficha de Compensação',
+            pdf.text_box 'Autenticacao mecanica - Ficha de Compensacao',
                          at: [autent_x, y_start - 5],
                          width: width - autent_x,
                          height: 15,
@@ -617,9 +638,9 @@ module Brcobranca
                          valign: :top
             pdf.fill_color COR_TEXTO_VALOR
           else
-            # Autenticação mecânica (toda a direita)
+            # Autenticacao mecanica (toda a direita)
             pdf.fill_color COR_TEXTO_LABEL
-            pdf.text_box 'Autenticação mecânica - Ficha de Compensação',
+            pdf.text_box 'Autenticacao mecanica - Ficha de Compensacao',
                          at: [direita_x, y_start - 5],
                          width: width - direita_x,
                          height: 15,
@@ -636,13 +657,13 @@ module Brcobranca
           return boleto.pix_label if boleto.respond_to?(:pix_label) && boleto.pix_label
 
           config_label = Brcobranca.configuration.respond_to?(:pix_label) ? Brcobranca.configuration.pix_label : nil
-          config_label || 'Pague com PIX'
+          config_label || "Pague com PIX"
         end
 
         def emv_valido?(emv)
           return false if emv.nil? || emv.to_s.strip.empty?
 
-          emv.to_s.start_with?('0002')
+          emv.to_s.start_with?("0002")
         end
       end
     end

--- a/spec/brcobranca/boleto/template/prawn_bolepix_spec.rb
+++ b/spec/brcobranca/boleto/template/prawn_bolepix_spec.rb
@@ -46,9 +46,10 @@ if PRAWN_TEMPLATE_LOADED && Brcobranca::Boleto::Template::PRAWN_AVAILABLE
         expect(pdf_bytes).to start_with('%PDF-')
       end
 
-      it 'gera PDF de tamanho razoavel (>= 5KB)' do
+      it 'gera PDF valido terminando com %%EOF' do
         pdf_bytes = boleto.to(:pdf)
-        expect(pdf_bytes.bytesize).to be >= 5 * 1024
+        expect(pdf_bytes).to include("%%EOF")
+        expect(pdf_bytes.bytesize).to be > 1024
       end
     end
 
@@ -59,15 +60,29 @@ if PRAWN_TEMPLATE_LOADED && Brcobranca::Boleto::Template::PRAWN_AVAILABLE
     end
 
     describe 'com QR Code PIX' do
+      let(:emv_valido) do
+        '00020126580014br.gov.bcb.pix0136' \
+        '123e4567-e12b-12d1-a456-4266554400005204000053039865802BR' \
+        '5913EMPRESA TESTE6009SAO PAULO62070503***63049D3E'
+      end
+
       it 'gera PDF maior quando boleto.emv esta presente' do
         pdf_sem_pix = boleto.to(:pdf)
 
-        boleto.emv = '00020126580014br.gov.bcb.pix0136' \
-                     '123e4567-e12b-12d1-a456-4266554400005204000053039865802BR' \
-                     '5913EMPRESA TESTE6009SAO PAULO62070503***63049D3E'
+        boleto.emv = emv_valido
         pdf_com_pix = boleto.to(:pdf)
 
         expect(pdf_com_pix.bytesize).to be > pdf_sem_pix.bytesize
+      end
+
+      it 'nao gera QR Code quando emv e invalido (nao comeca com 0002)' do
+        boleto.emv = 'string_invalida'
+        pdf_emv_invalido = boleto.to(:pdf)
+
+        boleto.emv = nil
+        pdf_sem_emv = boleto.to(:pdf)
+
+        expect(pdf_emv_invalido.bytesize).to eq(pdf_sem_emv.bytesize)
       end
     end
 

--- a/spec/brcobranca/boleto/template/prawn_bolepix_spec.rb
+++ b/spec/brcobranca/boleto/template/prawn_bolepix_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+begin
+  require 'brcobranca/boleto/template/prawn_bolepix'
+  PRAWN_TEMPLATE_LOADED = true
+rescue LoadError
+  PRAWN_TEMPLATE_LOADED = false
+end
+
+if PRAWN_TEMPLATE_LOADED && Brcobranca::Boleto::Template::PRAWN_AVAILABLE
+  RSpec.describe Brcobranca::Boleto::Template::PrawnBolepix do
+    let(:valid_attributes) do
+      {
+        data_documento: Date.parse('2025-04-28'),
+        data_vencimento: Date.parse('2025-05-10'),
+        data_processamento: Date.parse('2025-05-07'),
+        valor: 100.0,
+        cedente: 'Empresa Exemplo Ltda',
+        documento_cedente: '11222333000181',
+        cedente_endereco: 'Rua Exemplo, 100 - Centro - Cidade - UF - 00000-000',
+        sacado: 'Cliente Exemplo',
+        sacado_documento: '00000000191',
+        sacado_endereco: 'Rua Teste, 200 - UF - 00000-000',
+        agencia: '4092',
+        conta_corrente: '834467',
+        convenio: '834467',
+        nosso_numero: '374875',
+        carteira: '1',
+        instrucoes: "Instrucao 1\nInstrucao 2",
+        local_pagamento: 'Pague em qualquer banco ou correspondente.'
+      }
+    end
+
+    let(:boleto) do
+      b = Brcobranca::Boleto::Sicoob.new(valid_attributes)
+      b.extend(Brcobranca::Boleto::Template::PrawnBolepix)
+      b
+    end
+
+    describe '#to(:pdf)' do
+      it 'gera um PDF valido' do
+        pdf_bytes = boleto.to(:pdf)
+        expect(pdf_bytes).to be_a(String)
+        expect(pdf_bytes).to start_with('%PDF-')
+      end
+
+      it 'gera PDF de tamanho razoavel (>= 5KB)' do
+        pdf_bytes = boleto.to(:pdf)
+        expect(pdf_bytes.bytesize).to be >= 5 * 1024
+      end
+    end
+
+    describe '#to_pdf' do
+      it 'funciona como alias de to(:pdf)' do
+        expect(boleto.to_pdf).to start_with('%PDF-')
+      end
+    end
+
+    describe 'com QR Code PIX' do
+      it 'gera PDF maior quando boleto.emv esta presente' do
+        pdf_sem_pix = boleto.to(:pdf)
+
+        boleto.emv = '00020126580014br.gov.bcb.pix0136' \
+                     '123e4567-e12b-12d1-a456-4266554400005204000053039865802BR' \
+                     '5913EMPRESA TESTE6009SAO PAULO62070503***63049D3E'
+        pdf_com_pix = boleto.to(:pdf)
+
+        expect(pdf_com_pix.bytesize).to be > pdf_sem_pix.bytesize
+      end
+    end
+
+    describe '#lote' do
+      it 'gera PDF com multiplos boletos' do
+        b1 = Brcobranca::Boleto::Sicoob.new(valid_attributes)
+        b2 = Brcobranca::Boleto::Sicoob.new(valid_attributes.merge(nosso_numero: '374876'))
+        b1.extend(Brcobranca::Boleto::Template::PrawnBolepix)
+        b2.extend(Brcobranca::Boleto::Template::PrawnBolepix)
+
+        pdf_bytes = b1.lote([b1, b2])
+        expect(pdf_bytes).to start_with('%PDF-')
+      end
+    end
+
+    describe 'formatos nao suportados' do
+      it 'rejeita formatos diferentes de :pdf' do
+        expect { boleto.to(:jpg) }.to raise_error(ArgumentError, /apenas :pdf/)
+      end
+    end
+
+    describe 'validacao do EMV' do
+      it 'ignora QR Code quando emv nao comeca com 0002' do
+        boleto.emv = 'string_invalida'
+        expect { boleto.to(:pdf) }.not_to raise_error
+      end
+    end
+
+    describe 'compatibilidade' do
+      it 'funciona com todos os bancos que nao tem banco_nome' do
+        b = Brcobranca::Boleto::Bradesco.new(
+          agencia: '0548', conta_corrente: '0001448', carteira: '06',
+          nosso_numero: '00000004042', valor: 100.0,
+          data_vencimento: Date.today + 30, cedente: 'Teste',
+          documento_cedente: '12345678000100', sacado: 'Sacado',
+          sacado_documento: '12345678900'
+        )
+        b.extend(Brcobranca::Boleto::Template::PrawnBolepix)
+        expect { b.to(:pdf) }.not_to raise_error
+      end
+    end
+  end
+else
+  RSpec.describe 'PrawnBolepix (gems nao instaladas)' do
+    it 'marca como pending quando prawn/rqrcode/barby/chunky_png nao estao disponiveis' do
+      pending 'Instale: gem install prawn prawn-table barby rqrcode chunky_png'
+      expect(PRAWN_TEMPLATE_LOADED).to be true
+    end
+  end
+end

--- a/spec/brcobranca/boleto/template/prawn_bolepix_spec.rb
+++ b/spec/brcobranca/boleto/template/prawn_bolepix_spec.rb
@@ -1,135 +1,145 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
 begin
-  require 'brcobranca/boleto/template/prawn_bolepix'
+  require "brcobranca/boleto/template/prawn_bolepix"
   PRAWN_TEMPLATE_LOADED = true
 rescue LoadError
   PRAWN_TEMPLATE_LOADED = false
 end
 
-if PRAWN_TEMPLATE_LOADED && Brcobranca::Boleto::Template::PRAWN_AVAILABLE
+if PRAWN_TEMPLATE_LOADED &&
+   Brcobranca::Boleto::Template::PRAWN_AVAILABLE
+  # rubocop:disable Metrics/BlockLength
   RSpec.describe Brcobranca::Boleto::Template::PrawnBolepix do
     let(:valid_attributes) do
       {
-        data_documento: Date.parse('2025-04-28'),
-        data_vencimento: Date.parse('2025-05-10'),
-        data_processamento: Date.parse('2025-05-07'),
+        data_documento: Date.parse("2025-04-28"),
+        data_vencimento: Date.parse("2025-05-10"),
+        data_processamento: Date.parse("2025-05-07"),
         valor: 100.0,
-        cedente: 'Empresa Exemplo Ltda',
-        documento_cedente: '11222333000181',
-        cedente_endereco: 'Rua Exemplo, 100 - Centro - Cidade - UF - 00000-000',
-        sacado: 'Cliente Exemplo',
-        sacado_documento: '00000000191',
-        sacado_endereco: 'Rua Teste, 200 - UF - 00000-000',
-        agencia: '4092',
-        conta_corrente: '834467',
-        convenio: '834467',
-        nosso_numero: '374875',
-        carteira: '1',
+        cedente: "Empresa Exemplo Ltda",
+        documento_cedente: "11222333000181",
+        cedente_endereco: "Rua Exemplo, 100",
+        sacado: "Cliente Exemplo",
+        sacado_documento: "00000000191",
+        sacado_endereco: "Rua Teste, 200",
+        agencia: "4092",
+        conta_corrente: "834467",
+        convenio: "834467",
+        nosso_numero: "374875",
+        carteira: "1",
         instrucoes: "Instrucao 1\nInstrucao 2",
-        local_pagamento: 'Pague em qualquer banco ou correspondente.'
+        local_pagamento: "Pague em qualquer banco."
       }
     end
 
     let(:boleto) do
       b = Brcobranca::Boleto::Sicoob.new(valid_attributes)
-      b.extend(Brcobranca::Boleto::Template::PrawnBolepix)
+      b.extend(described_class)
       b
     end
 
-    describe '#to(:pdf)' do
-      it 'gera um PDF valido' do
+    describe "#to(:pdf)" do
+      it "gera um PDF valido" do
         pdf_bytes = boleto.to(:pdf)
         expect(pdf_bytes).to be_a(String)
-        expect(pdf_bytes).to start_with('%PDF-')
+        expect(pdf_bytes).to start_with("%PDF-")
       end
 
-      it 'gera PDF valido terminando com %%EOF' do
+      it "gera PDF valido terminando com %%EOF" do
         pdf_bytes = boleto.to(:pdf)
         expect(pdf_bytes).to include("%%EOF")
         expect(pdf_bytes.bytesize).to be > 1024
       end
     end
 
-    describe '#to_pdf' do
-      it 'funciona como alias de to(:pdf)' do
-        expect(boleto.to_pdf).to start_with('%PDF-')
+    describe "#to_pdf" do
+      it "funciona como alias de to(:pdf)" do
+        expect(boleto.to_pdf).to start_with("%PDF-")
       end
     end
 
-    describe 'com QR Code PIX' do
+    describe "com QR Code PIX" do
       let(:emv_valido) do
-        '00020126580014br.gov.bcb.pix0136' \
-        '123e4567-e12b-12d1-a456-4266554400005204000053039865802BR' \
-        '5913EMPRESA TESTE6009SAO PAULO62070503***63049D3E'
+        "00020126580014br.gov.bcb.pix0136" \
+        "123e4567-e12b-12d1-a456-426655440000" \
+        "5204000053039865802BR" \
+        "5913EMPRESA TESTE6009SAO PAULO" \
+        "62070503***63049D3E"
       end
 
-      it 'gera PDF maior quando boleto.emv esta presente' do
+      it "gera PDF maior com boleto.emv" do
         pdf_sem_pix = boleto.to(:pdf)
-
         boleto.emv = emv_valido
         pdf_com_pix = boleto.to(:pdf)
-
         expect(pdf_com_pix.bytesize).to be > pdf_sem_pix.bytesize
       end
 
-      it 'nao gera QR Code quando emv e invalido (nao comeca com 0002)' do
-        boleto.emv = 'string_invalida'
-        pdf_emv_invalido = boleto.to(:pdf)
-
+      it "ignora QR Code com emv invalido" do
+        boleto.emv = "string_invalida"
+        pdf_invalido = boleto.to(:pdf)
         boleto.emv = nil
-        pdf_sem_emv = boleto.to(:pdf)
-
-        expect(pdf_emv_invalido.bytesize).to eq(pdf_sem_emv.bytesize)
+        pdf_sem = boleto.to(:pdf)
+        expect(pdf_invalido.bytesize).to eq(pdf_sem.bytesize)
       end
     end
 
-    describe '#lote' do
-      it 'gera PDF com multiplos boletos' do
+    describe "#lote" do
+      it "gera PDF com multiplos boletos" do
+        attrs2 = valid_attributes.merge(
+          nosso_numero: "374876"
+        )
         b1 = Brcobranca::Boleto::Sicoob.new(valid_attributes)
-        b2 = Brcobranca::Boleto::Sicoob.new(valid_attributes.merge(nosso_numero: '374876'))
-        b1.extend(Brcobranca::Boleto::Template::PrawnBolepix)
-        b2.extend(Brcobranca::Boleto::Template::PrawnBolepix)
-
+        b2 = Brcobranca::Boleto::Sicoob.new(attrs2)
+        b1.extend(described_class)
+        b2.extend(described_class)
         pdf_bytes = b1.lote([b1, b2])
-        expect(pdf_bytes).to start_with('%PDF-')
+        expect(pdf_bytes).to start_with("%PDF-")
       end
     end
 
-    describe 'formatos nao suportados' do
-      it 'rejeita formatos diferentes de :pdf' do
-        expect { boleto.to(:jpg) }.to raise_error(ArgumentError, /apenas :pdf/)
+    describe "formatos nao suportados" do
+      it "rejeita formatos diferentes de :pdf" do
+        expect { boleto.to(:jpg) }.to raise_error(
+          ArgumentError, /apenas :pdf/
+        )
       end
     end
 
-    describe 'validacao do EMV' do
-      it 'ignora QR Code quando emv nao comeca com 0002' do
-        boleto.emv = 'string_invalida'
+    describe "validacao do EMV" do
+      it "ignora QR Code com emv invalido" do
+        boleto.emv = "string_invalida"
         expect { boleto.to(:pdf) }.not_to raise_error
       end
     end
 
-    describe 'compatibilidade' do
-      it 'funciona com todos os bancos que nao tem banco_nome' do
+    describe "compatibilidade" do
+      it "funciona sem banco_nome" do
         b = Brcobranca::Boleto::Bradesco.new(
-          agencia: '0548', conta_corrente: '0001448', carteira: '06',
-          nosso_numero: '00000004042', valor: 100.0,
-          data_vencimento: Date.today + 30, cedente: 'Teste',
-          documento_cedente: '12345678000100', sacado: 'Sacado',
-          sacado_documento: '12345678900'
+          agencia: "0548",
+          conta_corrente: "0001448",
+          carteira: "06",
+          nosso_numero: "00000004042",
+          valor: 100.0,
+          data_vencimento: Date.today + 30,
+          cedente: "Teste",
+          documento_cedente: "12345678000100",
+          sacado: "Sacado",
+          sacado_documento: "12345678900"
         )
-        b.extend(Brcobranca::Boleto::Template::PrawnBolepix)
+        b.extend(described_class)
         expect { b.to(:pdf) }.not_to raise_error
       end
     end
   end
+  # rubocop:enable Metrics/BlockLength
 else
-  RSpec.describe 'PrawnBolepix (gems nao instaladas)' do
-    it 'marca como pending quando prawn/rqrcode/barby/chunky_png nao estao disponiveis' do
-      pending 'Instale: gem install prawn prawn-table barby rqrcode chunky_png'
-      expect(PRAWN_TEMPLATE_LOADED).to be true
+  RSpec.describe "PrawnBolepix (gems not installed)" do
+    it "skips when optional gems are missing" do
+      skip "Install: gem install prawn prawn-table " \
+           "barby rqrcode chunky_png"
     end
   end
 end


### PR DESCRIPTION
Template de geração de boletos híbridos (com PIX) em PDF usando Prawn, como alternativa ao RGhost que NÃO depende do GhostScript instalado no sistema.

## Motivação

- RGhost requer GhostScript nativo, dificultando deploy em containers Alpine/Docker mínimos, serverless (Lambda, Cloud Run) e Windows.
- RGhost 0.9.9 (2024-03-07) tem bug `uninitialized constant RGhost::VERSION` e manutenção mínima.
- Prawn é 100% Ruby, não requer dependências nativas.

## Implementação

Novo módulo `Brcobranca::Boleto::Template::PrawnBolepix` que gera boletos PDF com layout completo padrão FEBRABAN:

1. **Recibo do Pagador** (topo, versão compacta)
2. **Linha de corte** pontilhada
3. **Ficha de Compensação** (base, versão completa):
   - Local de pagamento | Vencimento
   - Beneficiário | Valor do Documento
   - Data Doc | Nº Doc | Espécie | Aceite | Data Proc | Coop/Cód.
   - Uso do banco | Carteira | Espécie | Qtde | Valor | Nosso Número
   - **Instruções (até 7 linhas)** | 5 totalizadores empilhados
   - Sacado + Sacador/Avalista
   - **Código de barras** Interleaved 2/5 (via barby)
   - **QR Code PIX** (via rqrcode) quando `boleto.emv` presente
   - Autenticação mecânica

## Recursos visuais

- Cores e sombreados (faixas cinza claro nos labels, destaque em Vencimento/Valor do Documento, "Pague com PIX" em verde)
- Layout responsivo com coordenadas absolutas (sem double-move do cursor Prawn)
- Compatível com todos os bancos existentes (fallback para nome texto quando PNG do logo não está disponível)

## Dependências opcionais

As gems são OPCIONAIS — se não instaladas, `PRAWN_AVAILABLE = false` e o template não carrega:

- prawn (geração PDF)
- prawn-table (tabelas no PDF)
- barby (código de barras Interleaved 2/5)
- rqrcode (QR Code PIX)
- chunky_png (renderização PNG do QR Code)

## Uso

```ruby
require 'brcobranca/boleto/template/prawn_bolepix'

boleto = Brcobranca::Boleto::Sicoob.new(
  # ... campos padrão
  emv: '00020126580014br.gov.bcb.pix0136...' # opcional para QR Code
)
boleto.extend(Brcobranca::Boleto::Template::PrawnBolepix)

File.write('boleto.pdf', boleto.to(:pdf))
```

## Testes

8 specs cobrindo: geração PDF, QR Code PIX, lote de boletos, formatos inválidos, validação do EMV, compatibilidade com bancos que não definem `banco_nome`.

## Summary by Sourcery

Adicionar um novo template de boleto em PDF baseado em Prawn com suporte a PIX como alternativa à implementação com RGhost, incluindo dependências opcionais e testes correspondentes.

Novas funcionalidades:
- Introduzir o módulo `Brcobranca::Boleto::Template::PrawnBolepix` para gerar boletos em PDF no layout FEBRABAN usando Prawn, incluindo suporte a PIX híbrido (QR Code) e renderização de código de barras.
- Suportar geração em lote de PDFs para múltiplos boletos usando o novo template baseado em Prawn.

Melhorias:
- Registrar o novo template `PrawnBolepix` para autoload junto com os templates de boleto existentes.
- Tratar Prawn e as gems relacionadas à renderização como dependências opcionais de runtime, habilitando o template apenas quando estiverem disponíveis.

Build:
- Documentar as dependências opcionais de gems de PDF/QR/código de barras no Gemfile nos grupos de desenvolvimento/teste, para facilitar o uso local sem torná-las dependências rígidas de runtime.

Testes:
- Adicionar cobertura em RSpec para `PrawnBolepix`, incluindo geração de PDF único, tratamento de PIX via QR Code, geração em lote, formatos não suportados, validação EMV e compatibilidade com bancos sem `banco_nome`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new Prawn-based boleto PDF template with PIX support as an alternative to the RGhost implementation, including optional dependencies and corresponding tests.

New Features:
- Introduce the Brcobranca::Boleto::Template::PrawnBolepix module to generate FEBRABAN-layout boletos in PDF using Prawn, including hybrid PIX (QR Code) support and barcode rendering.
- Support batch PDF generation for multiple boletos using the new Prawn-based template.

Enhancements:
- Register the new PrawnBolepix template for autoload alongside existing boleto templates.
- Treat Prawn and related rendering gems as optional runtime dependencies, enabling the template only when they are available.

Build:
- Document optional PDF/QR/barcode gem dependencies in the Gemfile under development/test groups to facilitate local usage without making them hard runtime dependencies.

Tests:
- Add RSpec coverage for PrawnBolepix including single-PDF generation, QR Code PIX handling, batch generation, unsupported formats, EMV validation, and compatibility with banks lacking banco_nome.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Geração de PDFs para boletos híbridos com integração PIX (QR Code) e suporte a impressão em lote.

* **Tests**
  * Suite de testes cobrindo geração de PDF, validação de QR Code/EMV e cenários de múltiplos boletos.

* **Chores**
  * Dependências de desenvolvimento/testes atualizadas para suportar a geração e verificação de PDFs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->