### PR TITLE
[CI] Remove as versões de Ruby em EOL e conserta o ruby-head

### DIFF
--- a/.claude/skills/novo-banco/SKILL.md
+++ b/.claude/skills/novo-banco/SKILL.md
@@ -53,7 +53,7 @@ module Brcobranca
 end
 ```
 
-Atenção: o alvo é **Ruby 2.7** (RuboCop `TargetRubyVersion: 2.7`, matriz de CI a partir do 2.7) — nada de endless method, pattern matching ou outras novidades de 3.x.
+Atenção: o alvo é **Ruby 3.3** (RuboCop `TargetRubyVersion: 3.3`, matriz de CI a partir do 3.3) — nada de sintaxe exclusiva de 3.4 ou 4.0.
 
 O total tem que fechar: primeira parte (18) + segunda parte (25) = 43, + DV = 44. Se o tamanho não bater, `Base#codigo_barras` levanta `BoletoInvalido` dizendo o tamanho encontrado.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,12 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          # O BUNDLED WITH do Gemfile.lock e antigo demais para o ruby-head
-          # (quebra em `uninitialized constant Pathname::SEPARATOR_PAT`).
-          bundler: latest
+          # Usa o bundler que acompanha cada Ruby em vez do BUNDLED WITH
+          # (2.4.14) do Gemfile.lock. No ruby-head e a unica opcao que pode
+          # funcionar: todo bundler ja lancado quebra em `uninitialized
+          # constant Pathname::SEPARATOR_PAT`, corrigido apenas no master do
+          # rubygems (ruby/rubygems#9529).
+          bundler: default
           bundler-cache: true # runs 'bundle install' and caches installed
 
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,6 @@ jobs:
       fail-fast: false # don't fail all matrix builds if one fails
       matrix:
         ruby:
-          - '2.7'
-          - '3.0'
-          - '3.1'
-          - '3.2'
           - '3.3'
           - '3.4'
           - '4.0'
@@ -52,6 +48,9 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          # O BUNDLED WITH do Gemfile.lock e antigo demais para o ruby-head
+          # (quebra em `uninitialized constant Pathname::SEPARATOR_PAT`).
+          bundler: latest
           bundler-cache: true # runs 'bundle install' and caches installed
 
       - name: Run tests

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -24,7 +24,8 @@ jobs:
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.3'
+          bundler: latest
           bundler-cache: true
 
       - name: Lint Ruby files

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -25,7 +25,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.3'
-          bundler: latest
+          bundler: default
           bundler-cache: true
 
       - name: Lint Ruby files

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -37,7 +37,8 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.3'
+          bundler: latest
           bundler-cache: true # runs 'bundle install' and caches installed
 
       # Exit code 1 = ofensas encontradas (reportadas via SARIF, não quebram o job).

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -38,7 +38,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.3'
-          bundler: latest
+          bundler: default
           bundler-cache: true # runs 'bundle install' and caches installed
 
       # Exit code 1 = ofensas encontradas (reportadas via SARIF, não quebram o job).

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.3
   SuggestExtensions: false
 
 Style/FrozenStringLiteralComment:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ rake build / rake install / rake release      # tarefas do bundler/gem_tasks
 
 ### Compatibilidade de sintaxe (importante)
 
-O CI roda a matriz **Ruby 2.7 → 3.4 + head**, o gemspec exige `>= 2.7.0` e o RuboCop tem `TargetRubyVersion: 2.7`. Nada de sintaxe exclusiva de Ruby 3.x. `# frozen_string_literal: true` é obrigatório em todo arquivo.
+O CI roda a matriz **Ruby 3.3, 3.4, 4.0 + head**, o gemspec exige `>= 3.3.0` e o RuboCop tem `TargetRubyVersion: 3.3` — as versões anteriores saíram junto com o EOL upstream. Sintaxe de 3.3 é permitida; nada de 3.4+ exclusivo. `# frozen_string_literal: true` é obrigatório em todo arquivo.
 
 ## Arquitetura
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,3 @@ DEPENDENCIES
   simplecov
   test-prof
   timecop
-
-BUNDLED WITH
-   2.4.14

--- a/brcobranca.gemspec
+++ b/brcobranca.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.homepage = 'https://github.com/kivanio/brcobranca'
   gem.files = Dir['Rakefile', '{lib}/**/*', 'README*', 'LICENSE*', 'CHANGELOG*', 'History*']
   gem.require_paths = ['lib']
-  gem.required_ruby_version = '>= 2.7.0'
+  gem.required_ruby_version = '>= 3.3.0'
 
   gem.metadata = {
     'homepage_uri' => 'https://github.com/kivanio/brcobranca',


### PR DESCRIPTION
## Por quê

A matriz do CI ainda cobria **Ruby 2.7, 3.0, 3.1 e 3.2** — todas fora de suporte upstream. Desde o `Gemfile.lock` do 13.0.0 elas nem instalam mais:

```
parallel-2.1.0 requires ruby version >= 3.3, which is incompatible with the current version, 2.7.8
##[error]The process '/opt/hostedtoolcache/Ruby/2.7.8/x64/bin/bundle' failed with exit code 5
```

Como os jobs **linters** e **Rubocop** rodavam em 2.7, os três workflows estavam vermelhos por causa disso.

O job **ruby-head** falhava por outro motivo — o `BUNDLED WITH 2.4.14` do lockfile é antigo demais para o Ruby de desenvolvimento:

```
uninitialized constant Pathname::SEPARATOR_PAT
##[error]The process '/home/runner/.rubies/ruby-head/bin/bundle' failed with exit code 1
```

## O que muda

| | Antes | Depois |
| --- | --- | --- |
| Matriz do CI | 2.7, 3.0, 3.1, 3.2, 3.3, 3.4, 4.0, head | **3.3, 3.4, 4.0, head** |
| linters / Rubocop | Ruby 2.7 | **Ruby 3.3** |
| Bundler nos workflows | o do `BUNDLED WITH` (2.4.14) | **`bundler: latest`** |
| `required_ruby_version` | `>= 2.7.0` | **`>= 3.3.0`** |
| `TargetRubyVersion` | 2.7 | **3.3** |

`CLAUDE.md` e a skill `novo-banco` foram atualizados, já que documentavam a restrição de sintaxe do 2.7.

## Verificação local

```
983 examples, 0 failures
rubocop --parallel --fail-level E  → exit 0
```

Subir o `TargetRubyVersion` para 3.3 acrescenta **5 offenses** de convenção (2673 → 2678), nenhuma de nível E — o gate do CI continua passando.

## ⚠️ Breaking

Subir o `required_ruby_version` impede a instalação da gem em Ruby anterior ao 3.3. Merece nota de release.

## Resumo do Sourcery

Atualize a compatibilidade do projeto para Ruby 3.3 ou superior e estabilize a matriz de CI nas versões suportadas.

Correções de bugs:
- Corrige a execução do CI no ruby-head ao usar o Bundler padrão compatível com cada versão do Ruby.

Melhorias:
- Remove as versões de Ruby em EOL da matriz de CI e atualiza linters e RuboCop para Ruby 3.3.
- Eleva a versão mínima suportada da gem para Ruby 3.3.0.
- Atualiza a documentação e as orientações de desenvolvimento para refletir a compatibilidade com Ruby 3.3 e posteriores.

CI:
- Atualiza os workflows para testar Ruby 3.3, 3.4, 4.0 e ruby-head, usando o Bundler padrão de cada ambiente.

Documentação:
- Atualiza a documentação de compatibilidade de Ruby e as restrições de sintaxe para o novo requisito mínimo.

<details>
<summary>Original summary in English</summary>

## Resumo por Sourcery

Elevar a versão base do Ruby compatível com o projeto para 3.3 e alinhar o CI às versões do Ruby atualmente compatíveis.

Correções de bugs:
- Corrigir a execução do CI no ruby-head usando a versão do Bundler fornecida por cada ambiente Ruby.

Melhorias:
- Remover da matriz do CI as versões do Ruby que chegaram ao fim da vida útil e atualizar os destinos de linting para o Ruby 3.3.
- Elevar a versão mínima do Ruby compatível com a gem para 3.3.0.

CI:
- Atualizar os workflows de CI para testar o Ruby 3.3, 3.4, 4.0 e ruby-head com versões do Bundler compatíveis com cada ambiente.

Documentação:
- Atualizar as orientações de desenvolvimento e a documentação de compatibilidade de sintaxe para o Ruby 3.3 e versões posteriores.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Raise the project's supported Ruby baseline to 3.3 and align CI with currently supported Ruby versions.

Bug Fixes:
- Fix CI execution on ruby-head by using the Bundler version provided by each Ruby environment.

Enhancements:
- Remove end-of-life Ruby versions from the CI matrix and update linting targets to Ruby 3.3.
- Raise the gem's minimum supported Ruby version to 3.3.0.

CI:
- Update CI workflows to test Ruby 3.3, 3.4, 4.0, and ruby-head with environment-compatible Bundler versions.

Documentation:
- Update development guidance and syntax compatibility documentation for Ruby 3.3 and later.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Resumo do Sourcery

Atualize a compatibilidade do projeto para Ruby 3.3 ou superior e estabilize a matriz de CI nas versões suportadas.

Correções de bugs:
- Corrige a execução do CI no ruby-head ao usar o Bundler padrão compatível com cada versão do Ruby.

Melhorias:
- Remove as versões de Ruby em EOL da matriz de CI e atualiza linters e RuboCop para Ruby 3.3.
- Eleva a versão mínima suportada da gem para Ruby 3.3.0.
- Atualiza a documentação e as orientações de desenvolvimento para refletir a compatibilidade com Ruby 3.3 e posteriores.

CI:
- Atualiza os workflows para testar Ruby 3.3, 3.4, 4.0 e ruby-head, usando o Bundler padrão de cada ambiente.

Documentação:
- Atualiza a documentação de compatibilidade de Ruby e as restrições de sintaxe para o novo requisito mínimo.

<details>
<summary>Original summary in English</summary>

## Resumo por Sourcery

Elevar a versão base do Ruby compatível com o projeto para 3.3 e alinhar o CI às versões do Ruby atualmente compatíveis.

Correções de bugs:
- Corrigir a execução do CI no ruby-head usando a versão do Bundler fornecida por cada ambiente Ruby.

Melhorias:
- Remover da matriz do CI as versões do Ruby que chegaram ao fim da vida útil e atualizar os destinos de linting para o Ruby 3.3.
- Elevar a versão mínima do Ruby compatível com a gem para 3.3.0.

CI:
- Atualizar os workflows de CI para testar o Ruby 3.3, 3.4, 4.0 e ruby-head com versões do Bundler compatíveis com cada ambiente.

Documentação:
- Atualizar as orientações de desenvolvimento e a documentação de compatibilidade de sintaxe para o Ruby 3.3 e versões posteriores.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Raise the project's supported Ruby baseline to 3.3 and align CI with currently supported Ruby versions.

Bug Fixes:
- Fix CI execution on ruby-head by using the Bundler version provided by each Ruby environment.

Enhancements:
- Remove end-of-life Ruby versions from the CI matrix and update linting targets to Ruby 3.3.
- Raise the gem's minimum supported Ruby version to 3.3.0.

CI:
- Update CI workflows to test Ruby 3.3, 3.4, 4.0, and ruby-head with environment-compatible Bundler versions.

Documentation:
- Update development guidance and syntax compatibility documentation for Ruby 3.3 and later.

</details>

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Compatibilidade**
  - A versão mínima do Ruby foi atualizada para 3.3.
  - O suporte validado agora inclui Ruby 3.3, 3.4, 4.0 e versões de desenvolvimento.
  - O projeto passa a permitir sintaxes do Ruby 3.x, exceto recursos exclusivos do Ruby 3.4 ou superior.

- **Qualidade**
  - As verificações de lint e estilo foram alinhadas ao Ruby 3.3.
  - O Bundler mais recente passa a ser usado nos fluxos automatizados.

- **Documentação**
  - As informações de compatibilidade e requisitos foram atualizadas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->