### PR TITLE
[REFACTOR] Elimina duplicação no template bolepix e no retorno CNAB 240

### DIFF
--- a/lib/brcobranca.rb
+++ b/lib/brcobranca.rb
@@ -152,6 +152,7 @@ module Brcobranca
 
     module Cnab240
       autoload :Base,          'brcobranca/retorno/cnab240/base'
+      autoload :RegistrosTU,   'brcobranca/retorno/cnab240/registros_tu'
       autoload :Itau,          "brcobranca/retorno/cnab240/itau"
       autoload :Santander,     'brcobranca/retorno/cnab240/santander'
       autoload :Sicredi,       'brcobranca/retorno/cnab240/sicredi'

--- a/lib/brcobranca/boleto/template/rghost.rb
+++ b/lib/brcobranca/boleto/template/rghost.rb
@@ -85,6 +85,8 @@ module Brcobranca
                                                               y: "#{@y - 1.67} cm")
           end
 
+          desenha_qrcode_pix(doc, boleto)
+
           # Gerando stream
           formato = options.delete(:formato) || Brcobranca.configuration.formato
           resolucao = options.delete(:resolucao) || Brcobranca.configuration.resolucao
@@ -116,6 +118,8 @@ module Brcobranca
                                                                 y: "#{@y - 1.67} cm")
             end
 
+            desenha_qrcode_pix(doc, boleto)
+
             # Cria nova página se não for o último boleto
             doc.next_page unless index == boletos.length - 1
           end
@@ -140,6 +144,17 @@ module Brcobranca
           @x += x
           @y += y
           doc.moveto x: "#{@x} cm", y: "#{@y} cm"
+        end
+
+        # Ganchos sobrescritos pelo template RghostBolepix, que desenha o
+        # QRCode do PIX e os descontos/abatimentos. Aqui sao no-op ou apenas
+        # o deslocamento equivalente.
+        def desenha_qrcode_pix(_doc, _boleto); end
+
+        def desenha_descontos_e_abatimentos(_doc, _boleto); end
+
+        def move_para_linha_do_sacado(doc, _boleto)
+          move_more(doc, -15, -1.3)
         end
 
         # Monta o cabeçalho do layout do boleto
@@ -187,7 +202,7 @@ module Brcobranca
           move_more(doc, 5, 0)
           doc.show boleto.valor_documento.to_currency
 
-          move_more(doc, -15, -1.3)
+          move_para_linha_do_sacado(doc, boleto)
           doc.show "#{boleto.sacado} - #{boleto.sacado_documento.formata_documento}"
 
           move_more(doc, 0, -0.3)
@@ -265,6 +280,8 @@ module Brcobranca
 
           move_more(doc, 10.1, 0)
           doc.show boleto.valor_documento.to_currency
+
+          desenha_descontos_e_abatimentos(doc, boleto)
 
           if boleto.instrucoes
             doc.text_area boleto.instrucoes, width: '14 cm', text_align: :left, x: "#{@x -= 15.8} cm", y: "#{@y -= 0.9} cm",

--- a/lib/brcobranca/boleto/template/rghost_bolepix.rb
+++ b/lib/brcobranca/boleto/template/rghost_bolepix.rb
@@ -3,336 +3,59 @@
 begin
   require 'rghost'
 rescue LoadError
-  require 'rubygems' unless ENV['NO_RUBYGEMS']
-  gem 'rghost'
+  require 'rubygems'
   require 'rghost'
 end
 
 begin
   require 'rghost_barcode'
 rescue LoadError
-  require 'rubygems' unless ENV['NO_RUBYGEMS']
-  gem 'rghost_barcode'
+  require 'rubygems'
   require 'rghost_barcode'
 end
 
 module Brcobranca
   module Boleto
     module Template
-      # Templates para usar com Rghost
+      # Templantes para gerar boleto bancário com QRCode do PIX (bolepix).
+      #
+      # Reaproveita todo o desenho do template Rghost e sobrescreve apenas os
+      # ganchos que diferenciam o bolepix: o QRCode do PIX, gerado a partir do
+      # EMV do boleto, e os descontos/abatimentos.
       module RghostBolepix
-        extend self
-        include RGhost unless include?(RGhost)
-        RGhost::Config::GS[:external_encoding] = Brcobranca.configuration.external_encoding
-        RGhost::Config::GS[:default_params] << '-dNOSAFER'
-
-        # Gera o boleto em usando o formato desejado [:pdf, :jpg, :tif, :png, :ps, :laserjet, ... etc]
-        #
-        # @return [Stream]
-        # @see http://wiki.github.com/shairontoledo/rghost/supported-devices-drivers-and-formats Veja mais formatos na documentação do rghost.
-        # @see Rghost#modelo_generico Recebe os mesmos parâmetros do Rghost#modelo_generico.
-        def to(formato, options = {})
-          modelo_generico(self, options.merge!(formato: formato))
-        end
-
-        # Gera o boleto em usando o formato desejado [:pdf, :jpg, :tif, :png, :ps, :laserjet, ... etc]
-        #
-        # @return [Stream]
-        # @see http://wiki.github.com/shairontoledo/rghost/supported-devices-drivers-and-formats Veja mais formatos na documentação do rghost.
-        # @see Rghost#modelo_generico Recebe os mesmos parâmetros do Rghost#modelo_generico.
-        def lote(boletos, options = {})
-          modelo_generico_multipage(boletos, options)
-        end
-
-        #  Cria o métodos dinâmicos (to_pdf, to_gif e etc) com todos os fomátos válidos.
-        #
-        # @return [Stream]
-        # @see Rghost#modelo_generico Recebe os mesmos parâmetros do Rghost#modelo_generico.
-        # @example
-        #  @boleto.to_pdf #=> boleto gerado no formato pdf
-        def method_missing(m, *args)
-          method = m.to_s
-          if method.start_with?('to_')
-            modelo_generico(self, (args.first || {}).merge!(formato: method[3..]))
-          else
-            super
-          end
-        end
+        include Brcobranca::Boleto::Template::Rghost
 
         private
 
-        # Retorna um stream pronto para gravação em arquivo.
-        #
-        # @return [Stream]
-        # @param [Boleto] Instância de uma classe de boleto.
-        # @param [Hash] options Opção para a criação do boleto.
-        # @option options [Symbol] :resolucao Resolução em pixels.
-        # @option options [Symbol] :formato Formato desejado [:pdf, :jpg, :tif, :png, :ps, :laserjet, ... etc]
-        def modelo_generico(boleto, options = {})
-          doc = Document.new paper: :A4 # 210x297
+        # Desenha o QRCode do PIX quando o boleto tem EMV.
+        def desenha_qrcode_pix(doc, boleto)
+          return unless boleto.emv
 
-          template_path = File.join(File.dirname(__FILE__), '..', '..', 'arquivos', 'templates', 'modelo_generico.eps')
-
-          raise 'Não foi possível encontrar o template. Verifique o caminho' unless File.exist?(template_path)
-
-          modelo_generico_template(doc, boleto, template_path)
-          modelo_generico_cabecalho(doc, boleto)
-          modelo_generico_rodape(doc, boleto)
-
-          # Gerando codigo de barra com rghost_barcode
-          if boleto.codigo_barras
-            doc.barcode_interleaved2of5(boleto.codigo_barras, width: '10.3 cm', height: '1.3 cm', x: "#{@x - 1.7} cm",
-                                                              y: "#{@y - 1.67} cm")
-          end
-
-          # Gerando QRCode a partir de um emv
-          if boleto.emv
-            doc.barcode_qrcode(boleto.emv, width: '2.5 cm',
-                                           height: '2.5 cm',
-                                           eclevel: 'H',
-                                           x: "#{@x + 12.9} cm",
-                                           y: "#{@y - 2.50} cm")
-            move_more(doc, @x + 12.9, @y - 3.70)
-            doc.show 'Pague com PIX'
-          end
-
-          # Gerando stream
-          formato = options.delete(:formato) || Brcobranca.configuration.formato
-          resolucao = options.delete(:resolucao) || Brcobranca.configuration.resolucao
-          doc.render_stream(formato.to_sym, resolution: resolucao)
+          doc.barcode_qrcode(boleto.emv, width: '2.5 cm',
+                                         height: '2.5 cm',
+                                         eclevel: 'H',
+                                         x: "#{@x + 12.9} cm",
+                                         y: "#{@y - 2.50} cm")
+          move_more(doc, @x + 12.9, @y - 3.70)
+          doc.show 'Pague com PIX'
         end
 
-        # Retorna um stream para multiplos boletos pronto para gravação em arquivo.
-        #
-        # @return [Stream]
-        # @param [Array] Instâncias de classes de boleto.
-        # @param [Hash] options Opção para a criação do boleto.
-        # @option options [Symbol] :resolucao Resolução em pixels.
-        # @option options [Symbol] :formato Formato desejado [:pdf, :jpg, :tif, :png, :ps, :laserjet, ... etc]
-        def modelo_generico_multipage(boletos, options = {})
-          doc = Document.new paper: :A4 # 210x297
-
-          template_path = File.join(File.dirname(__FILE__), '..', '..', 'arquivos', 'templates', 'modelo_generico.eps')
-
-          raise 'Não foi possível encontrar o template. Verifique o caminho' unless File.exist?(template_path)
-
-          boletos.each_with_index do |boleto, index|
-            modelo_generico_template(doc, boleto, template_path)
-            modelo_generico_cabecalho(doc, boleto)
-            modelo_generico_rodape(doc, boleto)
-
-            # Gerando codigo de barra com rghost_barcode
-            if boleto.codigo_barras
-              doc.barcode_interleaved2of5(boleto.codigo_barras, width: '10.3 cm', height: '1.3 cm', x: "#{@x - 1.7} cm",
-                                                                y: "#{@y - 1.67} cm")
-            end
-
-            # Gerando QRCode a partir de um emv
-            if boleto.emv
-              doc.barcode_qrcode(boleto.emv, width: '2.5 cm',
-                                             height: '2.5 cm',
-                                             eclevel: 'H',
-                                             x: "#{@x + 12.9} cm",
-                                             y: "#{@y - 2.50} cm")
-              move_more(doc, @x + 12.9, @y - 3.70)
-              doc.show 'Pague com PIX'
-            end
-
-            # Cria nova página se não for o último boleto
-            doc.next_page unless index == boletos.length - 1
-          end
-          # Gerando stream
-          formato = options.delete(:formato) || Brcobranca.configuration.formato
-          resolucao = options.delete(:resolucao) || Brcobranca.configuration.resolucao
-          doc.render_stream(formato.to_sym, resolution: resolucao)
-        end
-
-        # Define o template a ser usado no boleto
-        def modelo_generico_template(doc, _boleto, template_path)
-          doc.define_template(:template, template_path, x: '0.5 cm', y: '2.7 cm')
-          doc.use_template :template
-
-          doc.define_tags do
-            tag :grande, size: 13
-            tag :maior, size: 15
-          end
-        end
-
-        def move_more(doc, x, y)
-          @x += x
-          @y += y
-          doc.moveto x: "#{@x} cm", y: "#{@y} cm"
-        end
-
-        # Monta o cabeçalho do layout do boleto
-        def modelo_generico_cabecalho(doc, boleto)
-          # INICIO Primeira parte do BOLETO
-          # Pontos iniciais em x e y
-          @x = 0.50
-          @y = 27.42
-          # LOGOTIPO do BANCO
-          doc.image boleto.logotipo, x: "#{@x} cm", y: "#{@y} cm"
-          # Dados
-
-          move_more(doc, 4.84, 0.02)
-          doc.show "#{boleto.banco}-#{boleto.banco_dv}", tag: :maior
-          move_more(doc, 2, 0)
-          doc.show boleto.codigo_barras.linha_digitavel, tag: :grande
-          move_more(doc, -6.5, -0.83)
-
-          doc.show boleto.cedente
-
-          move_more(doc, 15.8, 0)
-          doc.show boleto.agencia_conta_boleto
-
-          move_more(doc, -15.8, -0.9)
-          doc.show boleto.cedente_endereco
-
-          move_more(doc, 15.8, 0)
-          doc.show boleto.nosso_numero_boleto
-
-          move_more(doc, -15.8, -0.8)
-          doc.show boleto.documento_numero
-
-          move_more(doc, 3.5, 0)
-          doc.show boleto.especie
-
-          move_more(doc, 1.5, 0)
-          doc.show boleto.quantidade
-
-          move_more(doc, 2, 0)
-          doc.show boleto.documento_cedente.formata_documento.to_s
-
-          move_more(doc, 3.8, 0)
-          doc.show boleto.data_vencimento.to_s_br
-
-          move_more(doc, 5, 0)
-          doc.show boleto.valor_documento.to_currency
-
-          move_more(doc, -15.8, -0.75)
-          doc.show boleto.descontos_e_abatimentos&.to_currency
-
-          move_more(doc, 0.8, -0.55)
-          doc.show "#{boleto.sacado} - #{boleto.sacado_documento.formata_documento}"
-
-          move_more(doc, 0, -0.3)
-          doc.show boleto.sacado_endereco.to_s
-          return unless boleto.demonstrativo
-
-          doc.text_area boleto.demonstrativo, width: '18.5 cm', text_align: :left, x: "#{@x - 0.8} cm",
-                                              y: "#{@y - 0.9} cm", row_height: '0.4 cm'
-
-          # FIM Primeira parte do BOLETO
-        end
-
-        # Monta o corpo e rodapé do layout do boleto
-        def modelo_generico_rodape(doc, boleto)
-          # INICIO Segunda parte do BOLETO BB
-          # Pontos iniciais em x e y
-          @x = 0.50
-          @y = 12.22
-          # LOGOTIPO do BANCO
-          doc.image boleto.logotipo, x: "#{@x} cm", y: "#{@y} cm"
-
-          move_more(doc, 4.84, 0.01)
-          doc.show "#{boleto.banco}-#{boleto.banco_dv}", tag: :maior
-
-          move_more(doc, 2, 0)
-          doc.show boleto.codigo_barras.linha_digitavel, tag: :grande
-
-          move_more(doc, -6.5, -0.9)
-          doc.show boleto.local_pagamento
-
-          move_more(doc, 15.8, 0)
-          doc.show boleto.data_vencimento.to_s_br if boleto.data_vencimento
-
-          move_more(doc, -15.8, -0.8)
-          if boleto.cedente_endereco
-            doc.show boleto.cedente_endereco
-            move_more(doc, 1.2, 0.3)
-            doc.show boleto.cedente
-            move_more(doc, -1.2, -0.3)
-          else
-            doc.show boleto.cedente
-          end
-
-          move_more(doc, 15.8, 0)
-          doc.show boleto.agencia_conta_boleto
-
-          move_more(doc, -15.8, -0.9)
-          doc.show boleto.data_documento.to_s_br if boleto.data_documento
-
-          move_more(doc, 3.5, 0)
-          doc.show boleto.documento_numero
-
-          move_more(doc, 5.8, 0)
-          doc.show boleto.especie_documento
-
-          move_more(doc, 1.7, 0)
-          doc.show boleto.aceite
-
-          move_more(doc, 1.3, 0)
-
-          doc.show boleto.data_processamento.to_s_br if boleto.data_processamento
-
-          move_more(doc, 3.5, 0)
-          doc.show boleto.nosso_numero_boleto
-
-          move_more(doc, -12.1, -0.8)
-          if boleto.variacao
-            doc.show "#{boleto.carteira}-#{boleto.variacao}"
-          else
-            doc.show boleto.carteira
-          end
-
-          move_more(doc, 2, 0)
-          doc.show boleto.especie
-
-          move_more(doc, 10.1, 0)
-          doc.show boleto.valor_documento.to_currency
-
+        # Descontos e abatimentos no rodape. O deslocamento e simetrico, para
+        # nao mover o cursor de quem vem depois.
+        def desenha_descontos_e_abatimentos(doc, boleto)
           move_more(doc, 0, -0.8)
           doc.show boleto.descontos_e_abatimentos&.to_currency
 
           move_more(doc, 0, 0.8)
-          if boleto.instrucoes
-            doc.text_area boleto.instrucoes, width: '14 cm',
-                                             text_align: :left, x: "#{@x -= 15.8} cm",
-                                             y: "#{@y -= 0.9} cm",
-                                             row_height: '0.4 cm'
-            move_more(doc, 0, -2)
-          else
-            move_more(doc, -15.8, -0.9)
-            doc.show boleto.instrucao1
+        end
 
-            move_more(doc, 0, -0.4)
-            doc.show boleto.instrucao2
+        # Mesmo deslocamento total do Rghost (-15, -1.3), quebrado em dois
+        # passos para mostrar os descontos e abatimentos no meio do caminho.
+        def move_para_linha_do_sacado(doc, boleto)
+          move_more(doc, -15.8, -0.75)
+          doc.show boleto.descontos_e_abatimentos&.to_currency
 
-            move_more(doc, 0, -0.4)
-            doc.show boleto.instrucao3
-
-            move_more(doc, 0, -0.4)
-            doc.show boleto.instrucao4
-
-            move_more(doc, 0, -0.4)
-            doc.show boleto.instrucao5
-
-            move_more(doc, 0, -0.4)
-            doc.show boleto.instrucao6
-          end
-
-          move_more(doc, 0.5, -1.9)
-          if boleto.sacado && boleto.sacado_documento
-            sacado_info = "#{boleto.sacado} - CPF/CNPJ: #{boleto.sacado_documento.formata_documento}"
-            doc.show sacado_info
-          end
-
-          move_more(doc, 0, -0.4)
-          doc.show boleto.sacado_endereco.to_s
-
-          move_more(doc, 1.2, -0.93)
-          doc.show "#{boleto.avalista} - #{boleto.avalista_documento}" if boleto.avalista && boleto.avalista_documento
-          # FIM Segunda parte do BOLETO
+          move_more(doc, 0.8, -0.55)
         end
       end
     end

--- a/lib/brcobranca/retorno/cnab240/ailos.rb
+++ b/lib/brcobranca/retorno/cnab240/ailos.rb
@@ -4,33 +4,7 @@ module Brcobranca
   module Retorno
     module Cnab240
       class Ailos < Brcobranca::Retorno::Cnab240::Base
-        # Regex para remoção de headers e trailers além de registros diferentes de T ou U
-        REGEX_DE_EXCLUSAO_DE_REGISTROS_NAO_T_OU_U = /^((?!^.{7}3.{5}[T|U].*$).)*$/.freeze
-
-        def self.load_lines(file, options = {})
-          default_options = { except: REGEX_DE_EXCLUSAO_DE_REGISTROS_NAO_T_OU_U }
-          options = default_options.merge!(options)
-
-          Line.load_lines(file, options).each_slice(2).reduce([]) do |retornos, cnab_lines|
-            retornos << generate_retorno_based_on_cnab_lines(cnab_lines)
-          end
-        end
-
-        def self.generate_retorno_based_on_cnab_lines(cnab_lines)
-          retorno = new
-          cnab_lines.each do |line|
-            if line.tipo_registro == 'T'
-              Line::REGISTRO_T_FIELDS.each do |attr|
-                retorno.send(:"#{attr}=", line.send(attr))
-              end
-            else
-              Line::REGISTRO_U_FIELDS.each do |attr|
-                retorno.send(:"#{attr}=", line.send(attr))
-              end
-            end
-          end
-          retorno
-        end
+        extend Brcobranca::Retorno::Cnab240::RegistrosTU
 
         # Linha de mapeamento do retorno do arquivo CNAB 240
         # O registro CNAB 240 possui 2 tipos de registros que juntos geram um registro de retorno bancário

--- a/lib/brcobranca/retorno/cnab240/registros_tu.rb
+++ b/lib/brcobranca/retorno/cnab240/registros_tu.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Brcobranca
+  module Retorno
+    module Cnab240
+      # Carrega retornos CNAB 240 formados por pares de registros T e U.
+      #
+      # O registro CNAB 240 usa dois tipos de registro que juntos formam um
+      # retorno: o T, com os dados gerais da transacao, e o U, com os valores.
+      # Os bancos que seguem esse padrao sem particularidades apenas estendem
+      # este modulo; cada um define a propria classe Line com o layout e as
+      # listas REGISTRO_T_FIELDS e REGISTRO_U_FIELDS.
+      module RegistrosTU
+        # Regex para remocao de headers e trailers alem de registros
+        # diferentes de T ou U
+        REGEX_DE_EXCLUSAO_DE_REGISTROS_NAO_T_OU_U = /^((?!^.{7}3.{5}[T|U].*$).)*$/.freeze
+
+        def load_lines(file, options = {})
+          default_options = { except: REGEX_DE_EXCLUSAO_DE_REGISTROS_NAO_T_OU_U }
+          options = default_options.merge!(options)
+
+          self::Line.load_lines(file, options).each_slice(2).reduce([]) do |retornos, cnab_lines|
+            retornos << generate_retorno_based_on_cnab_lines(cnab_lines)
+          end
+        end
+
+        def generate_retorno_based_on_cnab_lines(cnab_lines)
+          retorno = new
+          cnab_lines.each do |line|
+            campos = line.tipo_registro == 'T' ? self::Line::REGISTRO_T_FIELDS : self::Line::REGISTRO_U_FIELDS
+            campos.each { |attr| retorno.send(:"#{attr}=", line.send(attr)) }
+          end
+          retorno
+        end
+      end
+    end
+  end
+end

--- a/lib/brcobranca/retorno/cnab240/santander.rb
+++ b/lib/brcobranca/retorno/cnab240/santander.rb
@@ -4,33 +4,7 @@ module Brcobranca
   module Retorno
     module Cnab240
       class Santander < Brcobranca::Retorno::Cnab240::Base
-        # Regex para remoção de headers e trailers além de registros diferentes de T ou U
-        REGEX_DE_EXCLUSAO_DE_REGISTROS_NAO_T_OU_U = /^((?!^.{7}3.{5}[T|U].*$).)*$/.freeze
-
-        def self.load_lines(file, options = {})
-          default_options = { except: REGEX_DE_EXCLUSAO_DE_REGISTROS_NAO_T_OU_U }
-          options = default_options.merge!(options)
-
-          Line.load_lines(file, options).each_slice(2).reduce([]) do |retornos, cnab_lines|
-            retornos << generate_retorno_based_on_cnab_lines(cnab_lines)
-          end
-        end
-
-        def self.generate_retorno_based_on_cnab_lines(cnab_lines)
-          retorno = new
-          cnab_lines.each do |line|
-            if line.tipo_registro == 'T'
-              Line::REGISTRO_T_FIELDS.each do |attr|
-                retorno.send(:"#{attr}=", line.send(attr))
-              end
-            else
-              Line::REGISTRO_U_FIELDS.each do |attr|
-                retorno.send(:"#{attr}=", line.send(attr))
-              end
-            end
-          end
-          retorno
-        end
+        extend Brcobranca::Retorno::Cnab240::RegistrosTU
 
         # Linha de mapeamento do retorno do arquivo CNAB 240
         # O registro CNAB 240 possui 2 tipos de registros que juntos geram um registro de retorno bancário

--- a/lib/brcobranca/retorno/cnab240/sicoob.rb
+++ b/lib/brcobranca/retorno/cnab240/sicoob.rb
@@ -4,33 +4,7 @@ module Brcobranca
   module Retorno
     module Cnab240
       class Sicoob < Brcobranca::Retorno::Cnab240::Base
-        # Regex para remoção de headers e trailers além de registros diferentes de T ou U
-        REGEX_DE_EXCLUSAO_DE_REGISTROS_NAO_T_OU_U = /^((?!^.{7}3.{5}[T|U].*$).)*$/.freeze
-
-        def self.load_lines(file, options = {})
-          default_options = { except: REGEX_DE_EXCLUSAO_DE_REGISTROS_NAO_T_OU_U }
-          options = default_options.merge!(options)
-
-          Line.load_lines(file, options).each_slice(2).reduce([]) do |retornos, cnab_lines|
-            retornos << generate_retorno_based_on_cnab_lines(cnab_lines)
-          end
-        end
-
-        def self.generate_retorno_based_on_cnab_lines(cnab_lines)
-          retorno = new
-          cnab_lines.each do |line|
-            if line.tipo_registro == 'T'
-              Line::REGISTRO_T_FIELDS.each do |attr|
-                retorno.send(:"#{attr}=", line.send(attr))
-              end
-            else
-              Line::REGISTRO_U_FIELDS.each do |attr|
-                retorno.send(:"#{attr}=", line.send(attr))
-              end
-            end
-          end
-          retorno
-        end
+        extend Brcobranca::Retorno::Cnab240::RegistrosTU
 
         # Linha de mapeamento do retorno do arquivo CNAB 240
         # O registro CNAB 240 possui 2 tipos de registros que juntos geram um registro de retorno bancário

--- a/lib/brcobranca/retorno/cnab240/sicredi.rb
+++ b/lib/brcobranca/retorno/cnab240/sicredi.rb
@@ -4,33 +4,7 @@ module Brcobranca
   module Retorno
     module Cnab240
       class Sicredi < Brcobranca::Retorno::Cnab240::Base
-        # Regex para remoção de headers e trailers além de registros diferentes de T ou U
-        REGEX_DE_EXCLUSAO_DE_REGISTROS_NAO_T_OU_U = /^((?!^.{7}3.{5}[T|U].*$).)*$/.freeze
-
-        def self.load_lines(file, options = {})
-          default_options = { except: REGEX_DE_EXCLUSAO_DE_REGISTROS_NAO_T_OU_U }
-          options = default_options.merge!(options)
-
-          Line.load_lines(file, options).each_slice(2).reduce([]) do |retornos, cnab_lines|
-            retornos << generate_retorno_based_on_cnab_lines(cnab_lines)
-          end
-        end
-
-        def self.generate_retorno_based_on_cnab_lines(cnab_lines)
-          retorno = new
-          cnab_lines.each do |line|
-            if line.tipo_registro == 'T'
-              Line::REGISTRO_T_FIELDS.each do |attr|
-                retorno.send(:"#{attr}=", line.send(attr))
-              end
-            else
-              Line::REGISTRO_U_FIELDS.each do |attr|
-                retorno.send(:"#{attr}=", line.send(attr))
-              end
-            end
-          end
-          retorno
-        end
+        extend Brcobranca::Retorno::Cnab240::RegistrosTU
 
         # Linha de mapeamento do retorno do arquivo CNAB 240
         # O registro CNAB 240 possui 2 tipos de registros que juntos geram um registro de retorno bancário


### PR DESCRIPTION
Refatoração pura: **nenhum spec foi alterado** — os 1027 exemplos continuam passando exatamente como estão. Saldo de **-413 / +88** linhas.

## 1. `rghost_bolepix.rb`: 340 → 63 linhas

O arquivo era **91,8% cópia** do `rghost.rb` — 191 das 221 linhas não-comentário idênticas. As únicas diferenças reais eram o QRCode do PIX e os descontos/abatimentos, ambos no meio de métodos grandes, o que tinha levado a duplicar o arquivo inteiro.

`RghostBolepix` passa a incluir `Rghost` e sobrescrever três ganchos:

| gancho | no `Rghost` | no `RghostBolepix` |
| --- | --- | --- |
| `desenha_qrcode_pix` | no-op | QRCode do EMV + "Pague com PIX" |
| `desenha_descontos_e_abatimentos` | no-op | mostra o valor (deslocamento simétrico) |
| `move_para_linha_do_sacado` | o `move_more(-15, -1.3)` que já existia | mesmo deslocamento total, em dois passos, com os descontos no meio |

O deslocamento confere: `-15,8 + 0,8 = -15,0` e `-0,75 - 0,55 = -1,30`.

### Como a equivalência foi verificada

O bolepix **não tem nenhum spec** — nenhum exemplo usa `gerador = :rghost_bolepix` nem o atributo `emv`. Como as specs não podem mudar, verifiquei por golden master: quatro variantes de boleto (com/sem `emv`, com/sem `descontos_e_abatimentos`) renderizadas em PNG antes e depois do refactor.

```
                         antes  =  depois
sem emv, sem descontos   032ac4a6c40c4d84…  ✔
com emv                  c8a9826df163d961…  ✔
com descontos            ed002da50b88a9ca…  ✔
com emv e descontos      23da00516676ba90…  ✔
```

Os oito hashes SHA256 (bolepix e rghost) batem exatamente.

## 2. Retorno CNAB 240: novo módulo `RegistrosTU`

`load_lines` e `generate_retorno_based_on_cnab_lines` estavam **idênticos em `ailos`, `santander`, `sicoob` e `sicredi`** — 22 linhas repetidas quatro vezes, mais a mesma constante de regex. Viraram `Cnab240::RegistrosTU`, que os quatro estendem. Usa `self::Line`, o mesmo padrão que o `RetornoCnab240` passou a adotar no #274.

O Itaú fica de fora de propósito: tem regex própria e a validação `validate_par_t_u!`.

## Verificação

```
1027 examples, 0 failures        (mesma contagem de antes)
rubocop --fail-level E → exit 0
rubocop total: 1949 → 1924 offenses
git status em spec/: 0 arquivos
```

## Observações para outra hora

- **`rghost_bolepix` não tem cobertura nenhuma.** Não incluí spec aqui por causa da restrição, mas vale um PR só para isso.
- No `desenha_qrcode_pix`, a linha `move_more(doc, @x + 12.9, @y - 3.70)` soma o próprio `@x` a si mesmo, já que `move_more` é relativo. Parece bug, mas é o comportamento atual e foi preservado tal e qual.
- A constante `REGEX_DE_EXCLUSAO_DE_REGISTROS_NAO_T_OU_U` deixou de existir nas quatro classes de banco (agora vive no módulo). Nenhum spec a referenciava.

## Resumo por Sourcery

Remover o código duplicado do template de boleto e do processamento de retornos CNAB 240, preservando o comportamento existente de renderização e análise.

Aprimoramentos:
- Centralizar a lógica compartilhada de análise dos registros de retorno CNAB 240 T/U para Ailos, Santander, Sicoob e Sicredi em um módulo reutilizável.
- Refatorar o template Rghost Bolepix para reutilizar o layout padrão do Rghost, preservando o comportamento de renderização do código QR do PIX e dos descontos.

Testes:
- Preservar o comportamento existente e verificar se todo o conjunto de testes continua passando sem modificar as especificações.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove duplicated boleto template and CNAB 240 return-processing code while preserving existing rendering and parsing behavior.

Enhancements:
- Centralize the shared CNAB 240 T/U return-record parsing logic for Ailos, Santander, Sicoob, and Sicredi in a reusable module.
- Refactor the Rghost Bolepix template to reuse the standard Rghost layout while preserving PIX QR code and discount rendering behavior.

Tests:
- Preserve existing behavior and verify that the full test suite continues to pass without modifying specs.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Novos Recursos**
  * Aprimorado o processamento de arquivos de retorno CNAB 240 para registros dos tipos T e U, com agrupamento e interpretação padronizados.
  * Adicionado suporte a novos retornos bancários utilizando esse processamento compartilhado.

* **Melhorias**
  * O template de boletos permite desenhar QR Code PIX, descontos e abatimentos de forma mais consistente.
  * O boleto BolePix passa a aproveitar o mesmo fluxo de geração do template principal, mantendo seus recursos específicos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->