### PR TITLE
[REFACTOR] Cobre o template bolepix e extrai os métodos abstratos

### DIFF
--- a/lib/brcobranca.rb
+++ b/lib/brcobranca.rb
@@ -8,6 +8,7 @@ require 'brcobranca/formatacao_string'
 require 'brcobranca/calculo_data'
 require 'brcobranca/currency'
 require 'brcobranca/validations'
+require 'brcobranca/metodos_abstratos'
 require 'brcobranca/parse_line'
 require 'brcobranca/util/date'
 

--- a/lib/brcobranca/boleto/base.rb
+++ b/lib/brcobranca/boleto/base.rb
@@ -17,6 +17,11 @@ module Brcobranca
       # Validações
       include Brcobranca::Validations
 
+      extend Brcobranca::MetodosAbstratos
+
+      # Cada banco precisa implementar:
+      metodos_abstratos :nosso_numero_boleto, :agencia_conta_boleto, :codigo_barras_segunda_parte
+
       # <b>REQUERIDO</b>: Número do convênio/contrato do cliente junto ao banco emissor
       attr_accessor :convenio
       # <b>REQUERIDO</b>: Tipo de moeda utilizada (Real(R$) e igual a 9)
@@ -163,16 +168,6 @@ module Brcobranca
         nosso_numero.modulo11(mapeamento: { 10 => 0, 11 => 0 })
       end
 
-      # @abstract Deverá ser sobreescrito para cada banco.
-      def nosso_numero_boleto
-        raise Brcobranca::NaoImplementado, 'Sobreescreva este método na classe referente ao banco que você esta criando'
-      end
-
-      # @abstract Deverá ser sobreescrito para cada banco.
-      def agencia_conta_boleto
-        raise Brcobranca::NaoImplementado, 'Sobreescreva este método na classe referente ao banco que você esta criando'
-      end
-
       # Valor total do documento: <b>quantidate * valor</b>
       # @return [Float]
       def valor_documento
@@ -223,13 +218,6 @@ module Brcobranca
                      message: "tamanho(#{codigo.size}) prévio do código de barras(#{codigo}) inválido, deveria ser 43 dígitos")
           raise Brcobranca::BoletoInvalido, self
         end
-      end
-
-      # Monta a segunda parte do código de barras, que é específico para cada banco.
-      #
-      # @abstract Deverá ser sobreescrito para cada banco.
-      def codigo_barras_segunda_parte
-        raise Brcobranca::NaoImplementado, 'Sobreescreva este método na classe referente ao banco que você esta criando'
       end
 
       private

--- a/lib/brcobranca/metodos_abstratos.rb
+++ b/lib/brcobranca/metodos_abstratos.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Brcobranca
+  # Declara os metodos que a classe base espera de cada banco.
+  #
+  # Chamar um deles numa classe que nao o implementou levanta
+  # Brcobranca::NaoImplementado com a mensagem padrao.
+  #
+  #   class Base
+  #     extend Brcobranca::MetodosAbstratos
+  #
+  #     metodos_abstratos :cod_banco, :nome_banco
+  #   end
+  module MetodosAbstratos
+    MENSAGEM = 'Sobreescreva este método na classe referente ao banco que você esta criando'
+
+    def metodos_abstratos(*nomes)
+      nomes.each do |nome|
+        define_method(nome) do |*_args|
+          raise Brcobranca::NaoImplementado, MENSAGEM
+        end
+      end
+    end
+  end
+end

--- a/lib/brcobranca/remessa/cnab240/base.rb
+++ b/lib/brcobranca/remessa/cnab240/base.rb
@@ -4,6 +4,12 @@ module Brcobranca
   module Remessa
     module Cnab240
       class Base < Brcobranca::Remessa::Base
+        extend Brcobranca::MetodosAbstratos
+
+        # Cada banco precisa implementar:
+        metodos_abstratos :complemento_header, :versao_layout_arquivo, :versao_layout_lote,
+                          :convenio_lote, :nome_banco, :cod_banco, :info_conta, :codigo_convenio
+
         # convenio do cedente
         attr_accessor :convenio
         # mensagem 1
@@ -373,33 +379,6 @@ module Brcobranca
           end
         end
 
-        # Complemento do registro
-        #
-        # Este metodo deve ser sobrescrevido na classe do banco
-        #
-        def complemento_header
-          raise Brcobranca::NaoImplementado,
-                'Sobreescreva este método na classe referente ao banco que você esta criando'
-        end
-
-        # Numero da versao do layout do arquivo
-        #
-        # Este metodo deve ser sobrescrevido na classe do banco
-        #
-        def versao_layout_arquivo
-          raise Brcobranca::NaoImplementado,
-                'Sobreescreva este método na classe referente ao banco que você esta criando'
-        end
-
-        # Numero da versao do layout do lote
-        #
-        # Este metodo deve ser sobrescrevido na classe do banco
-        #
-        def versao_layout_lote
-          raise Brcobranca::NaoImplementado,
-                'Sobreescreva este método na classe referente ao banco que você esta criando'
-        end
-
         # Densidade de gravacao do arquivo
         def densidade_gravacao
           '00000'
@@ -413,51 +392,6 @@ module Brcobranca
         # Uso exclusivo da Empresa
         def uso_exclusivo_empresa
           ''.rjust(20, '0')
-        end
-
-        # Informacoes do convenio para o lote
-        #
-        # Este metodo deve ser sobrescrevido na classe do banco
-        #
-        def convenio_lote
-          raise Brcobranca::NaoImplementado,
-                'Sobreescreva este método na classe referente ao banco que você esta criando'
-        end
-
-        # Nome do banco
-        #
-        # Este metodo deve ser sobrescrevido na classe do banco
-        #
-        def nome_banco
-          raise Brcobranca::NaoImplementado,
-                'Sobreescreva este método na classe referente ao banco que você esta criando'
-        end
-
-        # Codigo do banco
-        #
-        # Este metodo deve ser sobrescrevido na classe do banco
-        #
-        def cod_banco
-          raise Brcobranca::NaoImplementado,
-                'Sobreescreva este método na classe referente ao banco que você esta criando'
-        end
-
-        # Informacoes da conta do cedente
-        #
-        # Este metodo deve ser sobrescrevido na classe do banco
-        #
-        def info_conta
-          raise Brcobranca::NaoImplementado,
-                'Sobreescreva este método na classe referente ao banco que você esta criando'
-        end
-
-        # Codigo do convenio
-        #
-        # Este metodo deve ser sobrescrevido na classe do banco
-        #
-        def codigo_convenio
-          raise Brcobranca::NaoImplementado,
-                'Sobreescreva este método na classe referente ao banco que você esta criando'
         end
 
         # Complemento do Segmento R

--- a/lib/brcobranca/remessa/cnab240/base_correspondente.rb
+++ b/lib/brcobranca/remessa/cnab240/base_correspondente.rb
@@ -4,6 +4,11 @@ module Brcobranca
   module Remessa
     module Cnab240
       class BaseCorrespondente < Brcobranca::Remessa::Base
+        extend Brcobranca::MetodosAbstratos
+
+        # Cada banco precisa implementar:
+        metodos_abstratos :complemento_header, :convenio_lote, :cod_banco, :info_conta, :codigo_convenio
+
         # convenio do cedente
         attr_accessor :convenio
         # mensagem 1
@@ -248,51 +253,6 @@ module Brcobranca
           arquivo << monta_trailer_arquivo(contador, ((pagamentos.size * 2) + (contador * 2) + 2))
 
           arquivo.join("\r\n").remove_accents.upcase
-        end
-
-        # Complemento do registro
-        #
-        # Este metodo deve ser sobrescrevido na classe do banco
-        #
-        def complemento_header
-          raise Brcobranca::NaoImplementado,
-                'Sobreescreva este método na classe referente ao banco que você esta criando'
-        end
-
-        # Informacoes do convenio para o lote
-        #
-        # Este metodo deve ser sobrescrevido na classe do banco
-        #
-        def convenio_lote
-          raise Brcobranca::NaoImplementado,
-                'Sobreescreva este método na classe referente ao banco que você esta criando'
-        end
-
-        # Codigo do banco
-        #
-        # Este metodo deve ser sobrescrevido na classe do banco
-        #
-        def cod_banco
-          raise Brcobranca::NaoImplementado,
-                'Sobreescreva este método na classe referente ao banco que você esta criando'
-        end
-
-        # Informacoes da conta do cedente
-        #
-        # Este metodo deve ser sobrescrevido na classe do banco
-        #
-        def info_conta
-          raise Brcobranca::NaoImplementado,
-                'Sobreescreva este método na classe referente ao banco que você esta criando'
-        end
-
-        # Codigo do convenio
-        #
-        # Este metodo deve ser sobrescrevido na classe do banco
-        #
-        def codigo_convenio
-          raise Brcobranca::NaoImplementado,
-                'Sobreescreva este método na classe referente ao banco que você esta criando'
         end
 
         # Codigo para protesto

--- a/lib/brcobranca/remessa/cnab400/base.rb
+++ b/lib/brcobranca/remessa/cnab400/base.rb
@@ -4,6 +4,11 @@ module Brcobranca
   module Remessa
     module Cnab400
       class Base < Brcobranca::Remessa::Base
+        extend Brcobranca::MetodosAbstratos
+
+        # Cada banco precisa implementar:
+        metodos_abstratos :monta_detalhe, :info_conta, :cod_banco, :nome_banco, :complemento
+
         validates_presence_of :carteira, message: 'não pode estar em branco.'
 
         # Data da geracao do arquivo seguindo o padrao DDMMAA
@@ -50,15 +55,6 @@ module Brcobranca
           "9#{''.rjust(393, ' ')}#{sequencial.to_s.rjust(6, '0')}"
         end
 
-        # Registro detalhe do arquivo remessa
-        #
-        # Este metodo deve ser sobrescrevido na classe do banco
-        #
-        def monta_detalhe(_pagamento, _sequencial)
-          raise Brcobranca::NaoImplementado,
-                'Sobreescreva este método na classe referente ao banco que você esta criando'
-        end
-
         # Gera o arquivo com os registros
         #
         # @return [String]
@@ -94,42 +90,6 @@ module Brcobranca
 
           remittance.encode(remittance.encoding, universal_newline: true).encode(remittance.encoding,
                                                                                  crlf_newline: true)
-        end
-
-        # Informacoes referentes a conta do cedente
-        #
-        # Este metodo deve ser sobrescrevido na classe do banco
-        #
-        def info_conta
-          raise Brcobranca::NaoImplementado,
-                'Sobreescreva este método na classe referente ao banco que você esta criando'
-        end
-
-        # Numero do banco na camara de compensacao
-        #
-        # Este metodo deve ser sobrescrevido na classe do banco
-        #
-        def cod_banco
-          raise Brcobranca::NaoImplementado,
-                'Sobreescreva este método na classe referente ao banco que você esta criando'
-        end
-
-        # Nome por extenso do banco cobrador
-        #
-        # Este metodo deve ser sobrescrevido na classe do banco
-        #
-        def nome_banco
-          raise Brcobranca::NaoImplementado,
-                'Sobreescreva este método na classe referente ao banco que você esta criando'
-        end
-
-        # Complemento do registro header
-        #
-        # Este metodo deve ser sobrescrevido na classe do banco
-        #
-        def complemento
-          raise Brcobranca::NaoImplementado,
-                'Sobreescreva este método na classe referente ao banco que você esta criando'
         end
       end
     end

--- a/spec/brcobranca/boleto/template/rghost_bolepix_spec.rb
+++ b/spec/brcobranca/boleto/template/rghost_bolepix_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# O template e escolhido em Boleto::Base no momento da carga da classe, a
+# partir de Brcobranca.configuration.gerador, entao nao da para trocar o
+# gerador no meio da suite. Esta classe aplica o RghostBolepix do mesmo jeito
+# que a Base faria - o nome Itau e necessario porque Base#logotipo resolve o
+# arquivo .eps pelo nome da classe.
+module BolepixTeste
+  class Itau < Brcobranca::Boleto::Itau
+    extend Brcobranca::Boleto::Template::RghostBolepix
+    include Brcobranca::Boleto::Template::RghostBolepix
+  end
+end
+
+RSpec.describe Brcobranca::Boleto::Template::RghostBolepix do
+  let(:atributos) do
+    {
+      agencia: '0810',
+      conta_corrente: '53678',
+      carteira: '175',
+      nosso_numero: '12345678',
+      cedente: 'Kivanio Barbosa',
+      documento_cedente: '12345678912',
+      sacado: 'Claudio Pozzebom',
+      sacado_documento: '12345678900',
+      sacado_endereco: 'Rua Guarani 1, Sao Paulo, SP',
+      valor: 135.00,
+      data_documento: Date.parse('2026/08/01'),
+      data_vencimento: Date.parse('2026/08/28')
+    }
+  end
+
+  let(:emv) do
+    '00020101021226880014br.gov.bcb.pix2566qrcodepix.exemplo.com.br/cobv/12345' \
+      '20400005303986540510.005802BR'
+  end
+
+  let(:boleto) { BolepixTeste::Itau.new(atributos) }
+
+  it 'e o template escolhido pelo gerador :rghost_bolepix' do
+    expect(Brcobranca::Boleto::Template::Base.define_template(:rghost_bolepix)).to eq([described_class])
+  end
+
+  it 'reaproveita o desenho do template Rghost' do
+    expect(described_class.include?(Brcobranca::Boleto::Template::Rghost)).to be true
+  end
+
+  it 'gera um PDF valido' do
+    expect(boleto.to_pdf[0..3]).to eq '%PDF'
+  end
+
+  it 'responde aos formatos dinamicos herdados do Rghost' do
+    %w[pdf jpg png].each do |formato|
+      expect(boleto.send(:"to_#{formato}")).not_to be_empty
+    end
+  end
+
+  context 'com EMV informado' do
+    let(:boleto) { BolepixTeste::Itau.new(atributos.merge(emv: emv)) }
+
+    it 'desenha o QRCode do PIX' do
+      expect(boleto.to_ps).to include('Pague com PIX')
+    end
+
+    it 'gera um arquivo maior que o boleto sem PIX' do
+      expect(boleto.to_ps.bytesize).to be > BolepixTeste::Itau.new(atributos).to_ps.bytesize
+    end
+  end
+
+  context 'sem EMV' do
+    it 'nao desenha o QRCode do PIX' do
+      expect(boleto.to_ps).not_to include('Pague com PIX')
+    end
+  end
+
+  context 'com descontos e abatimentos' do
+    let(:boleto) { BolepixTeste::Itau.new(atributos.merge(descontos_e_abatimentos: 12.34)) }
+
+    it 'mostra o valor no boleto' do
+      expect(boleto.to_ps).to include('12,34')
+    end
+  end
+
+  context 'sem descontos e abatimentos' do
+    it 'gera o boleto normalmente' do
+      expect(boleto.descontos_e_abatimentos).to be_nil
+      expect(boleto.to_pdf[0..3]).to eq '%PDF'
+    end
+  end
+
+  context 'quando gera um lote' do
+    it 'aplica o template em todos os boletos' do
+      lote = BolepixTeste::Itau.lote([BolepixTeste::Itau.new(atributos.merge(emv: emv)),
+                                      BolepixTeste::Itau.new(atributos.merge(emv: emv))],
+                                     formato: :ps)
+
+      expect(lote.scan('Pague com PIX').size).to eq 2
+    end
+  end
+end


### PR DESCRIPTION
**Nenhum spec existente foi alterado.** Saldo em `lib/`: **-179 / +47**.

## 1. Specs para o `rghost_bolepix` (10 exemplos)

O template não tinha cobertura nenhuma — nenhum exemplo usava `gerador = :rghost_bolepix` nem o atributo `emv`. Era o buraco que o #285 expôs.

O template é escolhido em `Boleto::Base` no momento da carga da classe, a partir de `Brcobranca.configuration.gerador`, então não dá para trocar o gerador no meio da suíte. O spec aplica o módulo numa subclasse do Itaú, do mesmo jeito que a `Base` faria (o nome `Itau` importa: `Base#logotipo` resolve o `.eps` pelo nome da classe).

Cobre:

- o QRCode do PIX aparece **só** quando há `emv` — e não aparece quando não há;
- descontos e abatimentos saem no boleto;
- geração em lote aplica o template nos dois boletos;
- os `to_<formato>` dinâmicos herdados do `Rghost`;
- `define_template(:rghost_bolepix)` devolve este módulo.

As asserções olham o PostScript gerado (`to_ps`), então um erro de coordenada ou um gancho que pare de ser chamado aparece — não é só "gerou arquivo não-vazio".

## 2. `Brcobranca::MetodosAbstratos`

Este bloco aparecia **21 vezes** em quatro classes base:

```ruby
# Este metodo deve ser sobrescrevido na classe do banco
def cod_banco
  raise Brcobranca::NaoImplementado,
        'Sobreescreva este método na classe referente ao banco que você esta criando'
end
```

Virou uma declaração por classe:

```ruby
extend Brcobranca::MetodosAbstratos

# Cada banco precisa implementar:
metodos_abstratos :complemento_header, :versao_layout_arquivo, :versao_layout_lote,
                  :convenio_lote, :nome_banco, :cod_banco, :info_conta, :codigo_convenio
```

A mensagem é byte-idêntica, então os specs que a verificam (`base_spec`, `cnab240/base_spec`, `cnab400/base_spec`) passam sem alteração.

Os raises **condicionais** — HSBC, Banco do Brasil, Ailos — não foram tocados: têm mensagem própria e ficam no meio da lógica, não são declaração de método abstrato.

## Verificação

```
1037 examples, 0 failures      (1027 + 10 novos)
rubocop --fail-level E → exit 0
rubocop total: 1924 offenses   (mesmo número do master, com 2 arquivos a mais)
specs existentes modificados: 0
```

O golden master do bolepix (4 variantes renderizadas em PNG) continua batendo com o do #285, o que confirma que mexer no `Boleto::Base` não alterou o desenho.

## O que ficou de fora, e por quê

Depois de medir, três itens da lista de refactoring **não** compensam:

- **Setters duplicados** (`agencia=` 12x, `conta_corrente=` 8x): trocar `valor.to_s.rjust(4, '0')` por `format_agencia(valor)` acrescenta indireção e mexe em 15+ arquivos para ganhar pouco. É onde a tentativa parada em `.conductor/refactor` tinha começado, e não avançou.
- **`monta_segmento_p` do Santander e do Banco do Brasil** (86% e 77% iguais à base): diferem em seis pontos, e só dois deles têm gancho hoje. Remover os overrides exigiria **quatro ganchos novos na base**, que é usada por dez bancos, para desduplicar dois. A cópia aqui é defensável: cada `monta_segmento_p` é a transcrição auditável de um manual.
- **`load_lines` do retorno CNAB 400** (8 cópias idênticas de 5 linhas): a extração exigiria `extend` numa ordem específica em relação ao `ParseLine`, para o `super` cair no lugar certo. Restrição invisível para ganhar 20 linhas.

## Resumo por Sourcery

Centraliza as declarações de métodos abstratos e valida o comportamento do template Bolepix com especificações abrangentes de renderização.

Melhorias:
- Centraliza a declaração e o tratamento padrão de erros dos métodos abstratos específicos de bancos nas classes base de boletos e remessas.

Testes:
- Adiciona cobertura para o template de renderização Bolepix, incluindo a saída condicional do código QR do PIX, descontos, formatos dinâmicos, geração em lote e seleção de template.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize abstract method declarations and validate the Bolepix template behavior with comprehensive rendering specs.

Enhancements:
- Centralize the declaration and standard error handling of abstract bank-specific methods across boleto and remittance base classes.

Tests:
- Add coverage for the Bolepix rendering template, including conditional PIX QR code output, discounts, dynamic formats, batch generation, and template selection.

</details>