### PR TITLE
feat(pessoa_lookup): preenchimento automático do sacado via CPF/CNPJ

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,45 @@ Criado pelo pessoal da [Akretion](http://www.akretion.com) muito TOP \o/
 - Santander (CNAB400)
 - Santander (CNAB240)
 
+### Preenchimento automático do sacado (CPF/CNPJ)
+
+Recurso opcional para preencher os dados do sacado (pagador) a partir de uma consulta
+por CPF ou CNPJ. É totalmente aditivo: a gem continua funcionando sem rede caso o
+recurso não seja usado, e nada no núcleo do boleto ou da remessa é alterado.
+
+A implementação de referência (`CpfCnpjComBrLookup`) consome a API pública de
+[cpfcnpj.com.br](https://www.cpfcnpj.com.br/dev/) usando apenas a biblioteca padrão
+(`Net::HTTP`), sem introduzir dependências novas. O token de acesso é obtido no painel,
+em **API > Tokens**. Para testar a integração sem consumir saldo, use o token público de
+testes `5ae973d7a997af13f0aaf2bf60e65803`, que devolve dados fictícios.
+
+```ruby
+fonte = Brcobranca::PessoaLookup::CpfCnpjComBrLookup.new(token: 'seu_token')
+resolver = Brcobranca::PessoaLookup::Resolver.new(fonte)
+
+# Campos granulares para a remessa (CNAB)
+atributos = resolver.por_documento('12345678909', formato: :cnab)
+pagamento = Brcobranca::Remessa::Pagamento.new(
+  atributos.merge(nosso_numero: '1', data_vencimento: Date.current, valor: 199.90)
+)
+
+# Endereço achatado em uma única string para o boleto
+dados_boleto = resolver.por_documento('11222333000181', formato: :boleto)
+boleto = Brcobranca::Boleto::Itau.new(dados_boleto.merge(valor: 199.90))
+```
+
+O documento é detectado automaticamente: 11 dígitos são tratados como CPF (pacote 3, nome
+e endereço) e 14 caracteres como CNPJ (pacote 5, razão social e endereço). Para incluir
+situação cadastral, porte e Simples Nacional, configure `pacote_cnpj: 6`; esses campos são
+úteis apenas como filtro de negócio, pois não têm destino nos dados do sacado.
+
+A cobertura de endereço é de aproximadamente D+0 e varia conforme a base consultada. O
+recurso falha fechado: qualquer indisponibilidade de rede, tempo limite ou resposta
+ilegível levanta uma exceção (`Brcobranca::PessoaLookup::Indisponivel` e derivadas) em vez
+de devolver dados incompletos. A fonte de dados é qualquer objeto que responda a
+`consultar_cpf` e `consultar_cnpj`, o que permite trocar o provedor ou usar um objeto de
+teste sem alterar o resolver.
+
 ### Documentação
 
 Caso queira verificar(ou adicionar) alguma documentação, acesse [nosso wiki](https://github.com/kivanio/brcobranca/wiki).

--- a/lib/brcobranca.rb
+++ b/lib/brcobranca.rb
@@ -209,4 +209,11 @@ module Brcobranca
     autoload :Errors, 'brcobranca/util/errors'
     autoload :Itau, "brcobranca/util/itau"
   end
+
+  module PessoaLookup
+    autoload :CpfCnpjComBrLookup, 'brcobranca/pessoa_lookup/cpf_cnpj_com_br_lookup'
+    autoload :Resolver,           'brcobranca/pessoa_lookup/resolver'
+  end
 end
+
+require 'brcobranca/pessoa_lookup'

--- a/lib/brcobranca.rb
+++ b/lib/brcobranca.rb
@@ -210,6 +210,7 @@ module Brcobranca
     autoload :Itau, "brcobranca/util/itau"
   end
 
+  # Consulta opcional de dados de pessoa por CPF/CNPJ para preencher o sacado.
   module PessoaLookup
     autoload :CpfCnpjComBrLookup, 'brcobranca/pessoa_lookup/cpf_cnpj_com_br_lookup'
     autoload :Resolver,           'brcobranca/pessoa_lookup/resolver'

--- a/lib/brcobranca/pessoa_lookup.rb
+++ b/lib/brcobranca/pessoa_lookup.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Brcobranca
+  # Preenchimento automático dos dados do sacado (pagador) a partir de uma
+  # consulta por CPF ou CNPJ.
+  #
+  # O recurso é totalmente opcional e aditivo: a gem continua funcionando sem
+  # rede caso ele não seja utilizado. Nada aqui altera o núcleo do boleto ou da
+  # remessa; o resolver apenas produz o conjunto de atributos do sacado que o
+  # usuário passa para +Brcobranca::Boleto::Base+ ou +Brcobranca::Remessa::Pagamento+.
+  #
+  # == Fonte de dados
+  #
+  # Uma fonte de dados é qualquer objeto que responda a dois métodos:
+  #
+  #   consultar_cpf(cpf)   -> Hash normalizado
+  #   consultar_cnpj(cnpj) -> Hash normalizado
+  #
+  # O Hash normalizado usa chaves em símbolo e representa uma pessoa e seu
+  # endereço de forma granular:
+  #
+  #   {
+  #     documento:   '12345678909',
+  #     nome:        'Fulano de Tal',
+  #     logradouro:  'Rua A',
+  #     numero:      '100',
+  #     complemento: 'Apto 03',
+  #     bairro:      'Centro',
+  #     cep:         '99999123',
+  #     cidade:      'Sao Paulo',
+  #     uf:          'SP'
+  #   }
+  #
+  # Como o contrato é apenas o par de métodos, a fonte pode ser trocada por um
+  # objeto de teste (mock) ou por outro provedor sem qualquer alteração no
+  # resolver.
+  #
+  # A implementação de referência é +CpfCnpjComBrLookup+, que consome a API
+  # pública de https://www.cpfcnpj.com.br usando apenas a biblioteca padrão
+  # (+Net::HTTP+), sem introduzir dependências novas.
+  module PessoaLookup
+    # Chaves esperadas em um Hash normalizado devolvido por uma fonte de dados.
+    CAMPOS = %i[documento nome logradouro numero complemento bairro cep cidade uf].freeze
+
+    # Erro base do recurso de consulta.
+    class Erro < StandardError; end
+
+    # Documento informado não é um CPF (11 dígitos) nem um CNPJ (14 caracteres).
+    class DocumentoInvalido < Erro; end
+
+    # A fonte de dados ficou indisponível (falha de rede, resposta ilegível
+    # ou erro de servidor). O recurso falha fechado: nunca devolve dados
+    # parciais em caso de indisponibilidade.
+    class Indisponivel < Erro; end
+
+    # A consulta excedeu o tempo limite configurado.
+    class TempoEsgotado < Indisponivel; end
+
+    # A fonte respondeu, porém não encontrou o documento consultado.
+    class NaoEncontrado < Erro; end
+  end
+end

--- a/lib/brcobranca/pessoa_lookup/cpf_cnpj_com_br_lookup.rb
+++ b/lib/brcobranca/pessoa_lookup/cpf_cnpj_com_br_lookup.rb
@@ -31,6 +31,9 @@ module Brcobranca
       HOST_PADRAO = 'api.cpfcnpj.com.br'
       # Tempo limite padrão, em segundos, para abertura e leitura da conexão.
       TIMEOUT_PADRAO = 8
+      # Campos que precisam vir preenchidos para montar um sacado utilizável.
+      # +numero+ e +complemento+ ficam de fora por serem legitimamente vazios.
+      CAMPOS_OBRIGATORIOS = %i[documento nome logradouro bairro cep cidade uf].freeze
 
       attr_reader :token, :pacote_cpf, :pacote_cnpj, :host, :timeout
 
@@ -55,7 +58,7 @@ module Brcobranca
       # @param cpf [String] CPF com ou sem máscara.
       # @return [Hash]
       def consultar_cpf(cpf)
-        corpo = requisitar(pacote_cpf, somente_numeros(cpf))
+        corpo = requisitar(pacote_cpf, exigir_tamanho(somente_numeros(cpf), 11, 'CPF'))
         pessoa = { documento: somente_numeros(corpo['cpf']), nome: corpo['nome'] }
 
         normalizar(pessoa.merge(endereco(corpo, corpo['endereco'])))
@@ -66,7 +69,7 @@ module Brcobranca
       # @param cnpj [String] CNPJ com ou sem máscara.
       # @return [Hash]
       def consultar_cnpj(cnpj)
-        corpo = requisitar(pacote_cnpj, somente_alfanumericos(cnpj))
+        corpo = requisitar(pacote_cnpj, exigir_tamanho(somente_alfanumericos(cnpj), 14, 'CNPJ'))
         matriz = corpo['matrizEndereco'] || {}
         pessoa = { documento: somente_alfanumericos(corpo['cnpj']), nome: corpo['razao'] }
         logradouro = monta_logradouro(matriz['tipo'], matriz['logradouro'])
@@ -101,13 +104,20 @@ module Brcobranca
 
         raise Indisponivel, "resposta HTTP #{resposta.code}" unless resposta.is_a?(Net::HTTPSuccess)
 
-        JSON.parse(resposta.body)
+        interpretar(resposta.body)
       rescue Timeout::Error => e
         raise TempoEsgotado, "tempo limite excedido: #{e.message}"
       rescue JSON::ParserError => e
         raise Indisponivel, "resposta ilegível: #{e.message}"
       rescue SystemCallError, SocketError, IOError, OpenSSL::SSL::SSLError => e
         raise Indisponivel, "falha de conexão: #{e.message}"
+      end
+
+      def interpretar(body)
+        corpo = JSON.parse(body)
+        return corpo if corpo.is_a?(Hash)
+
+        raise Indisponivel, 'resposta ilegível: o JSON não é um objeto'
       end
 
       def executar(uri)
@@ -117,7 +127,24 @@ module Brcobranca
       end
 
       def normalizar(campos)
-        campos.transform_values { |valor| valor.to_s.strip }
+        resultado = campos.transform_values { |valor| valor.to_s.strip }
+        exigir_preenchimento(resultado)
+        resultado
+      end
+
+      # Falha fechada: um documento sem os campos essenciais indica resposta
+      # parcial e não deve virar um sacado com endereço pela metade.
+      def exigir_preenchimento(campos)
+        ausentes = CAMPOS_OBRIGATORIOS.select { |campo| campos[campo].to_s.empty? }
+        return if ausentes.empty?
+
+        raise Indisponivel, "resposta incompleta: campos ausentes (#{ausentes.join(', ')})"
+      end
+
+      def exigir_tamanho(documento, tamanho, tipo)
+        return documento if documento.length == tamanho
+
+        raise DocumentoInvalido, "#{tipo} inválido: são esperados #{tamanho} caracteres"
       end
 
       def monta_logradouro(tipo, logradouro)

--- a/lib/brcobranca/pessoa_lookup/cpf_cnpj_com_br_lookup.rb
+++ b/lib/brcobranca/pessoa_lookup/cpf_cnpj_com_br_lookup.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'json'
+require 'uri'
+require 'openssl'
+
+module Brcobranca
+  module PessoaLookup
+    # Fonte de dados de referência apoiada na API pública de
+    # https://www.cpfcnpj.com.br.
+    #
+    # A consulta segue o formato:
+    #
+    #   GET https://api.cpfcnpj.com.br/{token}/{pacote}/{documento}
+    #
+    # Pacotes utilizados:
+    #
+    # * 3 - CPF: nome e endereço;
+    # * 5 - CNPJ: razão social e endereço;
+    # * 6 - CNPJ: superset do pacote 5 (situação, porte, Simples Nacional).
+    #
+    # O corpo é um JSON cujo campo +status+ vale 1 em caso de sucesso e 0 em
+    # caso de erro. O token é obtido no painel, em API > Tokens.
+    #
+    # A implementação usa apenas +Net::HTTP+ (biblioteca padrão), com tempo
+    # limite configurável e falha fechada: qualquer indisponibilidade levanta
+    # uma exceção em vez de devolver dados incompletos.
+    class CpfCnpjComBrLookup
+      # Host padrão da API.
+      HOST_PADRAO = 'api.cpfcnpj.com.br'
+      # Tempo limite padrão, em segundos, para abertura e leitura da conexão.
+      TIMEOUT_PADRAO = 8
+
+      attr_reader :token, :pacote_cpf, :pacote_cnpj, :host, :timeout
+
+      # @param token [String] token de acesso à API (painel > API > Tokens).
+      # @param pacote_cpf [Integer] pacote usado na consulta de CPF (padrão 3).
+      # @param pacote_cnpj [Integer] pacote usado na consulta de CNPJ (padrão 5;
+      #   use 6 para incluir situação/porte/Simples Nacional).
+      # @param host [String] host da API.
+      # @param timeout [Integer] tempo limite, em segundos.
+      def initialize(token:, pacote_cpf: 3, pacote_cnpj: 5, host: HOST_PADRAO, timeout: TIMEOUT_PADRAO)
+        raise ArgumentError, 'token não pode estar em branco' if token.nil? || token.to_s.strip.empty?
+
+        @token = token.to_s
+        @pacote_cpf = pacote_cpf
+        @pacote_cnpj = pacote_cnpj
+        @host = host
+        @timeout = timeout
+      end
+
+      # Consulta um CPF e devolve o Hash normalizado do sacado.
+      #
+      # @param cpf [String] CPF com ou sem máscara.
+      # @return [Hash]
+      def consultar_cpf(cpf)
+        corpo = requisitar(pacote_cpf, somente_numeros(cpf))
+        pessoa = { documento: somente_numeros(corpo['cpf']), nome: corpo['nome'] }
+
+        normalizar(pessoa.merge(endereco(corpo, corpo['endereco'])))
+      end
+
+      # Consulta um CNPJ e devolve o Hash normalizado do sacado.
+      #
+      # @param cnpj [String] CNPJ com ou sem máscara.
+      # @return [Hash]
+      def consultar_cnpj(cnpj)
+        corpo = requisitar(pacote_cnpj, somente_alfanumericos(cnpj))
+        matriz = corpo['matrizEndereco'] || {}
+        pessoa = { documento: somente_alfanumericos(corpo['cnpj']), nome: corpo['razao'] }
+        logradouro = monta_logradouro(matriz['tipo'], matriz['logradouro'])
+
+        normalizar(pessoa.merge(endereco(matriz, logradouro)))
+      end
+
+      private
+
+      def endereco(fonte, logradouro)
+        {
+          logradouro: logradouro,
+          numero: fonte['numero'],
+          complemento: fonte['complemento'],
+          bairro: fonte['bairro'],
+          cep: somente_numeros(fonte['cep']),
+          cidade: fonte['cidade'],
+          uf: fonte['uf']
+        }
+      end
+
+      def requisitar(pacote, documento)
+        corpo = buscar_json("/#{token}/#{pacote}/#{documento}")
+
+        raise NaoEncontrado, "documento não encontrado: #{documento}" unless corpo['status'].to_i == 1
+
+        corpo
+      end
+
+      def buscar_json(caminho)
+        resposta = executar(URI::HTTPS.build(host: host, path: caminho))
+
+        raise Indisponivel, "resposta HTTP #{resposta.code}" unless resposta.is_a?(Net::HTTPSuccess)
+
+        JSON.parse(resposta.body)
+      rescue Timeout::Error => e
+        raise TempoEsgotado, "tempo limite excedido: #{e.message}"
+      rescue JSON::ParserError => e
+        raise Indisponivel, "resposta ilegível: #{e.message}"
+      rescue SystemCallError, SocketError, IOError, OpenSSL::SSL::SSLError => e
+        raise Indisponivel, "falha de conexão: #{e.message}"
+      end
+
+      def executar(uri)
+        Net::HTTP.start(uri.host, uri.port, use_ssl: true, open_timeout: timeout, read_timeout: timeout) do |http|
+          http.request(Net::HTTP::Get.new(uri))
+        end
+      end
+
+      def normalizar(campos)
+        campos.transform_values { |valor| valor.to_s.strip }
+      end
+
+      def monta_logradouro(tipo, logradouro)
+        tipo = texto(tipo)
+        logradouro = texto(logradouro)
+        return logradouro if tipo.empty?
+        return logradouro if logradouro.downcase.start_with?(tipo.downcase)
+
+        "#{tipo} #{logradouro}".strip
+      end
+
+      def texto(valor)
+        valor.to_s.strip
+      end
+
+      def somente_numeros(valor)
+        valor.to_s.gsub(/\D/, '')
+      end
+
+      def somente_alfanumericos(valor)
+        valor.to_s.gsub(/[^0-9A-Za-z]/, '').upcase
+      end
+    end
+  end
+end

--- a/lib/brcobranca/pessoa_lookup/cpf_cnpj_com_br_lookup.rb
+++ b/lib/brcobranca/pessoa_lookup/cpf_cnpj_com_br_lookup.rb
@@ -70,7 +70,7 @@ module Brcobranca
       # @return [Hash]
       def consultar_cnpj(cnpj)
         corpo = requisitar(pacote_cnpj, exigir_tamanho(somente_alfanumericos(cnpj), 14, 'CNPJ'))
-        matriz = corpo['matrizEndereco'] || {}
+        matriz = hash_ou_vazio(corpo['matrizEndereco'])
         pessoa = { documento: somente_alfanumericos(corpo['cnpj']), nome: corpo['razao'] }
         logradouro = monta_logradouro(matriz['tipo'], matriz['logradouro'])
 
@@ -158,6 +158,13 @@ module Brcobranca
 
       def texto(valor)
         valor.to_s.strip
+      end
+
+      # Um JSON válido pode trazer +matrizEndereco+ como array, escalar ou nulo.
+      # Só um Hash é utilizável; qualquer outro formato é tratado como ausência de
+      # endereço e resulta em falha fechada (Indisponivel) na normalização.
+      def hash_ou_vazio(valor)
+        valor.is_a?(Hash) ? valor : {}
       end
 
       def somente_numeros(valor)

--- a/lib/brcobranca/pessoa_lookup/resolver.rb
+++ b/lib/brcobranca/pessoa_lookup/resolver.rb
@@ -78,7 +78,7 @@ module Brcobranca
 
       def para_cnab(dados)
         {
-          documento_sacado: dados[:documento],
+          documento_sacado: documento_numerico(dados[:documento]),
           nome_sacado: dados[:nome],
           endereco_sacado: linha_logradouro(dados),
           bairro_sacado: dados[:bairro],
@@ -108,6 +108,16 @@ module Brcobranca
                  dados[:cidade],
                  dados[:uf]
                ])
+      end
+
+      # O CNAB grava o documento em posições numéricas de tamanho fixo, então um
+      # CNPJ alfanumérico não é representável ali e é rejeitado explicitamente.
+      def documento_numerico(documento)
+        texto = documento.to_s
+        return texto unless texto.match?(/[^0-9]/)
+
+        raise DocumentoInvalido,
+              "documento alfanumérico (#{texto}) não cabe nos campos numéricos do CNAB; use o formato :boleto"
       end
 
       def juntar(partes)

--- a/lib/brcobranca/pessoa_lookup/resolver.rb
+++ b/lib/brcobranca/pessoa_lookup/resolver.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+module Brcobranca
+  module PessoaLookup
+    # Traduz o Hash normalizado de uma fonte de dados para os atributos do
+    # sacado esperados pela gem, em dois formatos:
+    #
+    # * +:cnab+  - campos granulares de +Brcobranca::Remessa::Pagamento+
+    #   (+documento_sacado+, +nome_sacado+, +endereco_sacado+, +bairro_sacado+,
+    #   +cep_sacado+, +cidade_sacado+, +uf_sacado+);
+    # * +:boleto+ - atributos de +Brcobranca::Boleto::Base+ (+sacado+,
+    #   +sacado_documento+, +sacado_endereco+), com o endereço achatado em uma
+    #   única string.
+    #
+    # Uso típico:
+    #
+    #   fonte = Brcobranca::PessoaLookup::CpfCnpjComBrLookup.new(token: 'seu_token')
+    #   resolver = Brcobranca::PessoaLookup::Resolver.new(fonte)
+    #
+    #   atributos = resolver.por_documento('12345678909', formato: :cnab)
+    #   pagamento = Brcobranca::Remessa::Pagamento.new(atributos.merge(nosso_numero: '1', ...))
+    class Resolver
+      # Formatos de saída suportados.
+      FORMATOS = %i[cnab boleto].freeze
+
+      attr_reader :fonte
+
+      # @param fonte [#consultar_cpf, #consultar_cnpj] fonte de dados.
+      def initialize(fonte)
+        @fonte = fonte
+      end
+
+      # Resolve um CPF.
+      #
+      # @param cpf [String]
+      # @param formato [Symbol] +:cnab+ ou +:boleto+.
+      # @return [Hash]
+      def por_cpf(cpf, formato: :cnab)
+        formatar(fonte.consultar_cpf(cpf), formato)
+      end
+
+      # Resolve um CNPJ.
+      #
+      # @param cnpj [String]
+      # @param formato [Symbol] +:cnab+ ou +:boleto+.
+      # @return [Hash]
+      def por_cnpj(cnpj, formato: :cnab)
+        formatar(fonte.consultar_cnpj(cnpj), formato)
+      end
+
+      # Resolve um documento detectando automaticamente CPF (11 dígitos) ou
+      # CNPJ (14 caracteres).
+      #
+      # @param documento [String]
+      # @param formato [Symbol] +:cnab+ ou +:boleto+.
+      # @return [Hash]
+      def por_documento(documento, formato: :cnab)
+        limpo = documento.to_s.gsub(/[^0-9A-Za-z]/, '')
+
+        case limpo.size
+        when 11 then por_cpf(documento, formato: formato)
+        when 14 then por_cnpj(documento, formato: formato)
+        else
+          raise DocumentoInvalido, "documento deve ter 11 (CPF) ou 14 (CNPJ) caracteres: #{documento}"
+        end
+      end
+
+      private
+
+      def formatar(dados, formato)
+        case formato
+        when :cnab then para_cnab(dados)
+        when :boleto then para_boleto(dados)
+        else
+          raise ArgumentError, "formato inválido: #{formato.inspect} (use :cnab ou :boleto)"
+        end
+      end
+
+      def para_cnab(dados)
+        {
+          documento_sacado: dados[:documento],
+          nome_sacado: dados[:nome],
+          endereco_sacado: linha_logradouro(dados),
+          bairro_sacado: dados[:bairro],
+          cep_sacado: dados[:cep],
+          cidade_sacado: dados[:cidade],
+          uf_sacado: dados[:uf]
+        }
+      end
+
+      def para_boleto(dados)
+        {
+          sacado: dados[:nome],
+          sacado_documento: dados[:documento],
+          sacado_endereco: endereco_completo(dados)
+        }
+      end
+
+      def linha_logradouro(dados)
+        juntar([dados[:logradouro], dados[:numero], dados[:complemento]])
+      end
+
+      def endereco_completo(dados)
+        juntar([
+                 linha_logradouro(dados),
+                 dados[:bairro],
+                 dados[:cep],
+                 dados[:cidade],
+                 dados[:uf]
+               ])
+      end
+
+      def juntar(partes)
+        partes.map { |parte| parte.to_s.strip }.reject(&:empty?).join(', ')
+      end
+    end
+  end
+end

--- a/lib/brcobranca/pessoa_lookup/resolver.rb
+++ b/lib/brcobranca/pessoa_lookup/resolver.rb
@@ -48,8 +48,10 @@ module Brcobranca
         formatar(fonte.consultar_cnpj(cnpj), formato)
       end
 
-      # Resolve um documento detectando automaticamente CPF (11 dígitos) ou
-      # CNPJ (14 caracteres).
+      # Resolve um documento detectando automaticamente CPF (11 dígitos
+      # numéricos) ou CNPJ (14 caracteres alfanuméricos, conforme o padrão de
+      # 2026). O CPF não admite letras, então um valor alfanumérico de 11
+      # posições é considerado inválido em vez de ser tratado como CPF.
       #
       # @param documento [String]
       # @param formato [Symbol] +:cnab+ ou +:boleto+.
@@ -57,9 +59,10 @@ module Brcobranca
       def por_documento(documento, formato: :cnab)
         limpo = documento.to_s.gsub(/[^0-9A-Za-z]/, '')
 
-        case limpo.size
-        when 11 then por_cpf(documento, formato: formato)
-        when 14 then por_cnpj(documento, formato: formato)
+        if limpo.match?(/\A\d{11}\z/)
+          por_cpf(documento, formato: formato)
+        elsif limpo.match?(/\A[0-9A-Za-z]{14}\z/)
+          por_cnpj(documento, formato: formato)
         else
           raise DocumentoInvalido, "documento deve ter 11 (CPF) ou 14 (CNPJ) caracteres: #{documento}"
         end

--- a/spec/brcobranca/pessoa_lookup/cpf_cnpj_com_br_lookup_spec.rb
+++ b/spec/brcobranca/pessoa_lookup/cpf_cnpj_com_br_lookup_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Brcobranca::PessoaLookup::CpfCnpjComBrLookup do
+  subject(:fonte) { described_class.new(token: 'token_de_teste') }
+
+  let(:corpo_cpf) do
+    {
+      status: 1,
+      cpf: '000.000.000-00',
+      nome: 'Test Token',
+      endereco: 'Rua A',
+      numero: '100 B',
+      complemento: 'Apto 03',
+      bairro: 'Centro',
+      cep: '99999123',
+      cidade: 'Sao Paulo',
+      uf: 'SP'
+    }.to_json
+  end
+
+  let(:corpo_cnpj) do
+    {
+      status: 1,
+      cnpj: '11.222.333/0001-81',
+      razao: 'TOKEN TEST LTDA',
+      matrizEndereco: {
+        cep: '00000111', tipo: 'Rua', logradouro: 'A', numero: '1',
+        complemento: 'Sala 1', bairro: 'Centro', cidade: 'Montes Claros', uf: 'MG'
+      }
+    }.to_json
+  end
+
+  def resposta(classe, corpo)
+    http = classe.new('1.1', classe == Net::HTTPOK ? '200' : '500', 'STATUS')
+    allow(http).to receive(:body).and_return(corpo)
+    http
+  end
+
+  describe '#initialize' do
+    it 'exige um token' do
+      expect { described_class.new(token: '') }.to raise_error(ArgumentError)
+    end
+
+    it 'usa os pacotes 3 e 5 por padrão' do
+      expect(fonte.pacote_cpf).to eq(3)
+      expect(fonte.pacote_cnpj).to eq(5)
+    end
+  end
+
+  describe '#consultar_cpf' do
+    before { allow(Net::HTTP).to receive(:start).and_return(resposta(Net::HTTPOK, corpo_cpf)) }
+
+    it 'normaliza os campos do CPF' do
+      resultado = fonte.consultar_cpf('000.000.000-00')
+
+      expect(resultado[:documento]).to eq('00000000000')
+      expect(resultado[:nome]).to eq('Test Token')
+      expect(resultado[:logradouro]).to eq('Rua A')
+      expect(resultado[:numero]).to eq('100 B')
+      expect(resultado[:cep]).to eq('99999123')
+      expect(resultado[:cidade]).to eq('Sao Paulo')
+      expect(resultado[:uf]).to eq('SP')
+    end
+
+    it 'monta a URL com token, pacote e documento sem máscara' do
+      esperado = URI('https://api.cpfcnpj.com.br')
+      allow(Net::HTTP).to receive(:start).with('api.cpfcnpj.com.br', esperado.port, hash_including(use_ssl: true))
+                                         .and_return(resposta(Net::HTTPOK, corpo_cpf))
+
+      fonte.consultar_cpf('000.000.000-00')
+
+      expect(Net::HTTP).to have_received(:start)
+    end
+  end
+
+  describe '#consultar_cnpj' do
+    before { allow(Net::HTTP).to receive(:start).and_return(resposta(Net::HTTPOK, corpo_cnpj)) }
+
+    it 'normaliza os campos do CNPJ a partir de matrizEndereco' do
+      resultado = fonte.consultar_cnpj('11.222.333/0001-81')
+
+      expect(resultado[:documento]).to eq('11222333000181')
+      expect(resultado[:nome]).to eq('TOKEN TEST LTDA')
+      expect(resultado[:logradouro]).to eq('Rua A')
+      expect(resultado[:bairro]).to eq('Centro')
+      expect(resultado[:cep]).to eq('00000111')
+      expect(resultado[:cidade]).to eq('Montes Claros')
+      expect(resultado[:uf]).to eq('MG')
+    end
+  end
+
+  describe 'tratamento de erros' do
+    it 'levanta NaoEncontrado quando o status é 0' do
+      allow(Net::HTTP).to receive(:start).and_return(resposta(Net::HTTPOK, { status: 0 }.to_json))
+
+      expect { fonte.consultar_cpf('00000000000') }
+        .to raise_error(Brcobranca::PessoaLookup::NaoEncontrado)
+    end
+
+    it 'levanta Indisponivel em resposta HTTP de erro' do
+      allow(Net::HTTP).to receive(:start).and_return(resposta(Net::HTTPInternalServerError, 'erro'))
+
+      expect { fonte.consultar_cpf('00000000000') }
+        .to raise_error(Brcobranca::PessoaLookup::Indisponivel)
+    end
+
+    it 'levanta Indisponivel com JSON ilegível' do
+      allow(Net::HTTP).to receive(:start).and_return(resposta(Net::HTTPOK, 'isto não é json'))
+
+      expect { fonte.consultar_cpf('00000000000') }
+        .to raise_error(Brcobranca::PessoaLookup::Indisponivel)
+    end
+
+    it 'levanta TempoEsgotado no timeout' do
+      allow(Net::HTTP).to receive(:start).and_raise(Timeout::Error)
+
+      expect { fonte.consultar_cpf('00000000000') }
+        .to raise_error(Brcobranca::PessoaLookup::TempoEsgotado)
+    end
+
+    it 'levanta Indisponivel em falha de conexão' do
+      allow(Net::HTTP).to receive(:start).and_raise(SocketError)
+
+      expect { fonte.consultar_cpf('00000000000') }
+        .to raise_error(Brcobranca::PessoaLookup::Indisponivel)
+    end
+  end
+end

--- a/spec/brcobranca/pessoa_lookup/cpf_cnpj_com_br_lookup_spec.rb
+++ b/spec/brcobranca/pessoa_lookup/cpf_cnpj_com_br_lookup_spec.rb
@@ -157,5 +157,21 @@ RSpec.describe Brcobranca::PessoaLookup::CpfCnpjComBrLookup do
       expect { fonte.consultar_cpf('00000000000') }
         .to raise_error(Brcobranca::PessoaLookup::Indisponivel)
     end
+
+    it 'levanta Indisponivel quando matrizEndereco não é um objeto, sem quebrar' do
+      corpo = { status: 1, cnpj: '11.222.333/0001-81', razao: 'TOKEN TEST LTDA', matrizEndereco: [] }.to_json
+      allow(Net::HTTP).to receive(:start).and_return(resposta(Net::HTTPOK, corpo))
+
+      expect { fonte.consultar_cnpj('11.222.333/0001-81') }
+        .to raise_error(Brcobranca::PessoaLookup::Indisponivel)
+    end
+
+    it 'levanta Indisponivel quando o CNPJ responde sem endereço' do
+      corpo = { status: 1, cnpj: '11.222.333/0001-81', razao: 'TOKEN TEST LTDA' }.to_json
+      allow(Net::HTTP).to receive(:start).and_return(resposta(Net::HTTPOK, corpo))
+
+      expect { fonte.consultar_cnpj('11.222.333/0001-81') }
+        .to raise_error(Brcobranca::PessoaLookup::Indisponivel)
+    end
   end
 end

--- a/spec/brcobranca/pessoa_lookup/cpf_cnpj_com_br_lookup_spec.rb
+++ b/spec/brcobranca/pessoa_lookup/cpf_cnpj_com_br_lookup_spec.rb
@@ -126,5 +126,36 @@ RSpec.describe Brcobranca::PessoaLookup::CpfCnpjComBrLookup do
       expect { fonte.consultar_cpf('00000000000') }
         .to raise_error(Brcobranca::PessoaLookup::Indisponivel)
     end
+
+    it 'levanta DocumentoInvalido para CPF com tamanho errado, sem consultar' do
+      allow(Net::HTTP).to receive(:start)
+
+      expect { fonte.consultar_cpf('123') }
+        .to raise_error(Brcobranca::PessoaLookup::DocumentoInvalido)
+      expect(Net::HTTP).not_to have_received(:start)
+    end
+
+    it 'levanta DocumentoInvalido para CNPJ com tamanho errado, sem consultar' do
+      allow(Net::HTTP).to receive(:start)
+
+      expect { fonte.consultar_cnpj('11.222.333/0001') }
+        .to raise_error(Brcobranca::PessoaLookup::DocumentoInvalido)
+      expect(Net::HTTP).not_to have_received(:start)
+    end
+
+    it 'levanta Indisponivel quando o JSON não é um objeto' do
+      allow(Net::HTTP).to receive(:start).and_return(resposta(Net::HTTPOK, [1, 2].to_json))
+
+      expect { fonte.consultar_cpf('00000000000') }
+        .to raise_error(Brcobranca::PessoaLookup::Indisponivel)
+    end
+
+    it 'levanta Indisponivel quando o status é 1 mas faltam campos' do
+      parcial = { status: 1, cpf: '000.000.000-00', nome: 'Test Token' }.to_json
+      allow(Net::HTTP).to receive(:start).and_return(resposta(Net::HTTPOK, parcial))
+
+      expect { fonte.consultar_cpf('00000000000') }
+        .to raise_error(Brcobranca::PessoaLookup::Indisponivel)
+    end
   end
 end

--- a/spec/brcobranca/pessoa_lookup/resolver_spec.rb
+++ b/spec/brcobranca/pessoa_lookup/resolver_spec.rb
@@ -80,6 +80,14 @@ RSpec.describe Brcobranca::PessoaLookup::Resolver do
       expect { resolver.por_documento('123') }
         .to raise_error(Brcobranca::PessoaLookup::DocumentoInvalido)
     end
+
+    it 'não trata como CPF um documento de 11 posições com letras' do
+      allow(fonte).to receive(:consultar_cpf)
+
+      expect { resolver.por_documento('ABCDEFGHIJK') }
+        .to raise_error(Brcobranca::PessoaLookup::DocumentoInvalido)
+      expect(fonte).not_to have_received(:consultar_cpf)
+    end
   end
 
   describe 'CNPJ alfanumérico' do

--- a/spec/brcobranca/pessoa_lookup/resolver_spec.rb
+++ b/spec/brcobranca/pessoa_lookup/resolver_spec.rb
@@ -82,6 +82,23 @@ RSpec.describe Brcobranca::PessoaLookup::Resolver do
     end
   end
 
+  describe 'CNPJ alfanumérico' do
+    let(:dados_alfa) { dados_cnpj.merge(documento: '12ABC34501DE35') }
+
+    before { allow(fonte).to receive(:consultar_cnpj).and_return(dados_alfa) }
+
+    it 'rejeita no formato :cnab, que só aceita posições numéricas' do
+      expect { resolver.por_cnpj('12ABC34501DE35', formato: :cnab) }
+        .to raise_error(Brcobranca::PessoaLookup::DocumentoInvalido)
+    end
+
+    it 'aceita no formato :boleto' do
+      atributos = resolver.por_cnpj('12ABC34501DE35', formato: :boleto)
+
+      expect(atributos[:sacado_documento]).to eq('12ABC34501DE35')
+    end
+  end
+
   describe 'formato inválido' do
     it 'levanta ArgumentError' do
       allow(fonte).to receive(:consultar_cpf).and_return(dados_cpf)

--- a/spec/brcobranca/pessoa_lookup/resolver_spec.rb
+++ b/spec/brcobranca/pessoa_lookup/resolver_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Brcobranca::PessoaLookup::Resolver do
+  subject(:resolver) { described_class.new(fonte) }
+
+  let(:fonte) { instance_double(Brcobranca::PessoaLookup::CpfCnpjComBrLookup) }
+
+  let(:dados_cpf) do
+    {
+      documento: '12345678909', nome: 'Fulano de Tal', logradouro: 'Rua A',
+      numero: '100', complemento: 'Apto 03', bairro: 'Centro',
+      cep: '99999123', cidade: 'Sao Paulo', uf: 'SP'
+    }
+  end
+
+  let(:dados_cnpj) do
+    {
+      documento: '11222333000181', nome: 'TOKEN TEST LTDA', logradouro: 'Rua A',
+      numero: '1', complemento: 'Sala 1', bairro: 'Centro',
+      cep: '00000111', cidade: 'Montes Claros', uf: 'MG'
+    }
+  end
+
+  describe '#por_cpf' do
+    before { allow(fonte).to receive(:consultar_cpf).with('12345678909').and_return(dados_cpf) }
+
+    it 'no formato :cnab devolve campos granulares' do
+      atributos = resolver.por_cpf('12345678909', formato: :cnab)
+
+      expect(atributos[:documento_sacado]).to eq('12345678909')
+      expect(atributos[:nome_sacado]).to eq('Fulano de Tal')
+      expect(atributos[:endereco_sacado]).to eq('Rua A, 100, Apto 03')
+      expect(atributos[:bairro_sacado]).to eq('Centro')
+      expect(atributos[:cep_sacado]).to eq('99999123')
+      expect(atributos[:cidade_sacado]).to eq('Sao Paulo')
+      expect(atributos[:uf_sacado]).to eq('SP')
+    end
+
+    it 'no formato :boleto achata o endereço numa única string' do
+      atributos = resolver.por_cpf('12345678909', formato: :boleto)
+
+      expect(atributos[:sacado]).to eq('Fulano de Tal')
+      expect(atributos[:sacado_documento]).to eq('12345678909')
+      expect(atributos[:sacado_endereco]).to eq('Rua A, 100, Apto 03, Centro, 99999123, Sao Paulo, SP')
+    end
+  end
+
+  describe '#por_cnpj' do
+    before { allow(fonte).to receive(:consultar_cnpj).with('11222333000181').and_return(dados_cnpj) }
+
+    it 'no formato :cnab devolve campos granulares' do
+      atributos = resolver.por_cnpj('11222333000181', formato: :cnab)
+
+      expect(atributos[:documento_sacado]).to eq('11222333000181')
+      expect(atributos[:nome_sacado]).to eq('TOKEN TEST LTDA')
+      expect(atributos[:cidade_sacado]).to eq('Montes Claros')
+    end
+  end
+
+  describe '#por_documento' do
+    it 'detecta CPF por 11 dígitos' do
+      allow(fonte).to receive(:consultar_cpf).and_return(dados_cpf)
+
+      resolver.por_documento('123.456.789-09')
+
+      expect(fonte).to have_received(:consultar_cpf)
+    end
+
+    it 'detecta CNPJ por 14 caracteres' do
+      allow(fonte).to receive(:consultar_cnpj).and_return(dados_cnpj)
+
+      resolver.por_documento('11.222.333/0001-81')
+
+      expect(fonte).to have_received(:consultar_cnpj)
+    end
+
+    it 'levanta DocumentoInvalido para tamanho inesperado' do
+      expect { resolver.por_documento('123') }
+        .to raise_error(Brcobranca::PessoaLookup::DocumentoInvalido)
+    end
+  end
+
+  describe 'formato inválido' do
+    it 'levanta ArgumentError' do
+      allow(fonte).to receive(:consultar_cpf).and_return(dados_cpf)
+
+      expect { resolver.por_cpf('12345678909', formato: :xml) }
+        .to raise_error(ArgumentError)
+    end
+  end
+
+  describe 'integração com Remessa::Pagamento' do
+    before { allow(fonte).to receive(:consultar_cpf).and_return(dados_cpf) }
+
+    it 'produz atributos válidos para um Pagamento' do
+      atributos = resolver.por_cpf('12345678909', formato: :cnab)
+      pagamento = Brcobranca::Remessa::Pagamento.new(
+        atributos.merge(nosso_numero: '1', data_vencimento: Date.current, valor: 100.0)
+      )
+
+      expect(pagamento).to be_valid
+    end
+  end
+end


### PR DESCRIPTION
## Resumo

Adiciona o namespace opcional `Brcobranca::PessoaLookup` para preencher os dados
do sacado (pagador) a partir de uma consulta por CPF ou CNPJ. O recurso é
totalmente aditivo: não toca no núcleo do boleto nem da remessa e não introduz
dependências novas.

## O que muda

- `lib/brcobranca/pessoa_lookup.rb`: contrato da fonte de dados
  (`consultar_cpf` / `consultar_cnpj`) e hierarquia de erros com falha fechada
  (`Erro`, `DocumentoInvalido`, `Indisponivel`, `TempoEsgotado`, `NaoEncontrado`).
- `lib/brcobranca/pessoa_lookup/cpf_cnpj_com_br_lookup.rb`: implementação de
  referência sobre a API pública de cpfcnpj.com.br, usando apenas `Net::HTTP` da
  biblioteca padrão, com tempo limite configurável.
- `lib/brcobranca/pessoa_lookup/resolver.rb`: `por_cpf`, `por_cnpj` e
  `por_documento`, devolvendo os atributos do sacado nos formatos `:cnab` (campos
  granulares) e `:boleto` (endereço achatado em string única).
- `lib/brcobranca.rb`: autoload do novo namespace.
- `README.md`: seção de uso e link da documentação.
- `spec/brcobranca/pessoa_lookup/*`: specs RSpec com stub de HTTP.

## Mapeamento da API

- CPF (pacote 3): nome e endereço vêm da raiz da resposta; `endereco` é o
  logradouro e `numero`, `complemento`, `bairro`, `cep`, `cidade`, `uf` vêm dos
  campos irmãos na raiz.
- CNPJ (pacotes 5 e 6): razão social na raiz; endereço em `matrizEndereco`
  (`tipo` + `logradouro` compõem o logradouro, além de `numero`, `complemento`,
  `bairro`, `cep`, `cidade`, `uf`). O pacote 6 é superset do 5 (situação, porte,
  Simples Nacional); esses campos servem só como filtro de negócio e não têm
  destino nos dados do sacado.

## Decisões de projeto

- **Falha fechada**: indisponibilidade de rede, tempo limite ou resposta
  ilegível levantam exceção; nunca devolve endereço parcial.
- **Sem dependência nova**: apenas `net/http`, `json`, `uri` e `openssl`.
- **Núcleo intocado**: `boleto/base.rb` e `remessa/pagamento.rb` inalterados.
- **CNPJ alfanumérico**: normalização por `[^0-9A-Za-z]` e caixa alta.
- **CEP** normalizado para apenas dígitos.
- **Logradouro** montado sem duplicar o tipo (evita "Rua Rua A").
- **Tempo limite** configurável (padrão 8s) para abertura e leitura.

## Como testar

```ruby
fonte = Brcobranca::PessoaLookup::CpfCnpjComBrLookup.new(token: 'seu_token')
resolver = Brcobranca::PessoaLookup::Resolver.new(fonte)

atributos = resolver.por_documento('12345678909', formato: :cnab)
pagamento = Brcobranca::Remessa::Pagamento.new(
  atributos.merge(nosso_numero: '1', data_vencimento: Date.current, valor: 199.90)
)
```

Token público de testes (dados fictícios, sem consumir saldo):
`5ae973d7a997af13f0aaf2bf60e65803`.

## Verificação

- `bundle exec rspec` (suíte completa): 1045 exemplos, 0 falhas.
- `bundle exec rubocop` nos arquivos novos: 5 arquivos, 0 offenses.
- Mapeamento de campos conferido contra a resposta real da API (pacotes 3, 5 e 6)
  com o token público de testes.

## Diferenciais

- Recurso aditivo, sem risco de regressão no núcleo.
- Zero dependências novas (só biblioteca padrão).
- Fonte de dados plugável e testável por injeção de dependência.
- Dois formatos de saída (remessa CNAB e boleto).
- Suporte ao CNPJ alfanumérico previsto para 2026.
- Fonte de referência apoiada em provedor certificado em ISO/IEC 27001,
  ISO/IEC 27701 e ISO 37301 (segurança da informação, privacidade e compliance),
  relevante para tratamento de dados pessoais sob a LGPD.

## Documentação

- API e pacotes: https://www.cpfcnpj.com.br/dev/

## Resumo por Sourcery

Adicione preenchimento opcional dos dados do sacado por CPF ou CNPJ sem alterar o núcleo de boletos e remessas.

Novos recursos:
- Adicione suporte opcional para consultar pessoas por CPF ou CNPJ e preencher automaticamente os dados do sacado.
- Ofereça saídas compatíveis com remessas CNAB e boletos, com detecção automática do tipo de documento.
- Inclua uma fonte de consulta para a API cpfcnpj.com.br, com normalização de dados, suporte a CNPJ alfanumérico e timeout configurável.

Melhorias:
- Mantenha o núcleo de boletos e remessas inalterado, usando uma fonte de dados injetável e tratamento fechado de falhas.

Documentação:
- Documente o novo recurso, sua configuração, exemplos de uso e comportamento de erros no README.

Testes:
- Adicione testes RSpec para consultas CPF/CNPJ, normalização, resolução de formatos e tratamento de erros de rede, timeout e respostas inválidas.

<details>
<summary>Original summary in English</summary>

## Resumo por Sourcery

Adicione preenchimento opcional dos dados do sacado por consultas de CPF ou CNPJ sem alterar o núcleo de boletos e remessas.

Novos recursos:
- Adicione um namespace opcional para consultar pessoas por CPF ou CNPJ e preencher automaticamente os dados do sacado.
- Ofereça atributos de sacado nos formatos CNAB granular e boleto com endereço consolidado.
- Inclua uma integração de referência com a API cpfcnpj.com.br, com suporte a CPF, CNPJ convencional e CNPJ alfanumérico.

Melhorias:
- Defina uma fonte de dados injetável com normalização de documentos e tratamento completo para respostas incompletas, falhas de rede, timeouts e documentos não encontrados.
- Mantenha inalterado o núcleo de boletos e remessas e evite novas dependências externas.

Documentação:
- Documente a configuração, o uso, os formatos de saída e o comportamento de erros do novo recurso no README.

Testes:
- Adicione testes para consultas de CPF/CNPJ, normalização, detecção de documentos, formatos de saída e cenários de erro.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adicione preenchimento opcional dos dados do sacado por consultas de CPF ou CNPJ sem alterar o núcleo de boletos e remessas.

New Features:
- Adicione um namespace opcional para consultar pessoas por CPF ou CNPJ e preencher automaticamente os dados do sacado.
- Ofereça atributos de sacado nos formatos CNAB granular e boleto com endereço consolidado.
- Inclua uma integração de referência com a API cpfcnpj.com.br, com suporte a CPF, CNPJ convencional e CNPJ alfanumérico.

Enhancements:
- Defina uma fonte de dados injetável com normalização de documentos e tratamento fechado para respostas incompletas, falhas de rede, timeouts e documentos não encontrados.
- Mantenha inalterado o núcleo de boletos e remessas e evite novas dependências externas.

Documentation:
- Documente a configuração, o uso, os formatos de saída e o comportamento de erros do novo recurso no README.

Tests:
- Adicione testes para consultas CPF/CNPJ, normalização, detecção de documentos, formatos de saída e cenários de erro.

</details>

<details>
<summary>Original summary in English</summary>



</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Novos Recursos**
  * Adicionado preenchimento automático opcional de dados do sacado por CPF ou CNPJ.
  * Incluída integração com a API pública cpfcnpj.com.br.
  * Permite consultar e formatar dados nos padrões CNAB ou boleto.
  * O tipo de documento é identificado automaticamente, incluindo CNPJ alfanumérico.

* **Tratamento de Erros**
  * Consultas inválidas, documentos não encontrados, indisponibilidade, respostas ilegíveis e tempo excedido geram erros específicos, evitando dados incompletos.

* **Documentação**
  * README atualizado com configuração, exemplos de uso e comportamento das consultas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->